### PR TITLE
ci: upgrade deploy workflow and Fastfile

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -16,49 +16,37 @@ concurrency:
   group: ${{ github.ref }}/ios/deploy
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+
 jobs:
   deploy:
-    # needs: install-pods
-    runs-on: macos-15
+    runs-on: macos-26
     env:
         PRODUCT_NAME: 'WhoCallMe'
+        PACKAGE_NAME: 'com.credif.who'
         IOS_CERT_PATH: 'cert.p12'
         IOS_PROFILE_PATH: 'profile.mobileprovision'
         IOS_KEY_PATH: 'api-key.json'
+        IOS_IPA_PATH: './Output/IPA/App.ipa'
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
 
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.2.app
+          sudo xcode-select -s /Applications/Xcode_26.1.1.app
 
       - name: Install Mise
-        run: |
-            brew install mise
-
-      - name: Install Tuist
-        run: |
-          mise install tuist
-
-      # - name: Create Tuist cache key
-      #   id: tuist-cache-hash
-      #   run: echo "hash=${{ hashFiles('./Tuist/.build/workspace-state.json') }}" >> $GITHUB_OUTPUT
-
-      # - name: Cache Tuist
-      #   uses: actions/cache@v4
-      #   id: cache-pods
-      #   with:
-      #     path: ./Tuist/.builld
-      #     key: ${{ steps.tuist-cache-hash.outputs.hash }}
+        uses: jdx/mise-action@v2
 
       - name: Install Dependencies
         run: |
-          mise x -- tuist install
+          tuist install
 
-      - name: Build Tuist
+      - name: Generate Xcode Project
         run: |
-            mise x -- tuist build
+          tuist generate --no-open
 
       - name: Import signing certificate
         env:
@@ -74,11 +62,6 @@ jobs:
           echo "${{ secrets.IOS_PROFILE_DATA }}" > $IOS_PROFILE_PATH_BASE64
           base64 --decode -i $IOS_PROFILE_PATH_BASE64 -o $IOS_PROFILE_PATH
 
-      - name: Remove Network Security Exceptions
-        continue-on-error: true
-        run: |
-          /usr/libexec/PlistBuddy -c "delete :NSAppTransportSecurity:NSExceptionDomains" ./ios/$PRODUCT_NAME/Info.plist
-
       - name: Upgrade fastlane
         run: |
           sudo gem install fastlane
@@ -90,13 +73,73 @@ jobs:
           echo '${{ secrets.IOS_API_KEY }}' > $API_KEY_PATH_BASE64
           base64 --decode -i $API_KEY_PATH_BASE64 -o $IOS_KEY_PATH
           rm $API_KEY_PATH_BASE64
-          
-      - name: Build/Upload app
+
+      - name: Setup Certificates and Increment Version
         env:
-          PACKAGE_NAME: 'com.credif.who'
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           IOS_CERT_PWD: ${{ secrets.IOS_CERT_P12_PWD }}
           IOS_KEYCHAIN: ${{ secrets.IOS_KEYCHAIN }}
           IOS_KEYCHAIN_PWD: ${{ secrets.IOS_KEYCHAIN_PWD }}
+          IOS_KEY_PATH: ${{ env.IOS_KEY_PATH }}
         run: |
-          fastlane ios release description:'${{ github.event.inputs.body }}' isReleasing:${{ github.event.inputs.isReleasing }}
+          fastlane ios setup
+
+      - name: Create export options plist
+        env:
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          cat > ./exportOptions.plist <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store</string>
+            <key>teamID</key>
+            <string>$TEAM_ID</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>$PACKAGE_NAME</key>
+              <string>$PRODUCT_NAME</string>
+            </dict>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>uploadSymbols</key>
+            <true/>
+            <key>compileBitcode</key>
+            <false/>
+          </dict>
+          </plist>
+          EOF
+
+      - name: Build and Archive App
+        env:
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          SCHEME: App
+          ARCHIVE_PATH: ./Output/Archive
+        run: |
+          WORKSPACE=${PRODUCT_NAME}.xcworkspace
+
+          tuist xcodebuild archive \
+            -workspace $WORKSPACE \
+            -scheme "$SCHEME" \
+            -configuration Release \
+            -archivePath "$ARCHIVE_PATH"
+
+      - name: Export IPA
+        run: |
+          ARCHIVE_PATH=./Output/Archive.xcarchive
+          EXPORT_PATH=./Output/IPA
+          EXPORT_OPTIONS_PLIST=./exportOptions.plist
+
+          xcodebuild -exportArchive \
+            -archivePath $ARCHIVE_PATH \
+            -exportPath $EXPORT_PATH \
+            -exportOptionsPlist $EXPORT_OPTIONS_PLIST
+
+      - name: Upload to TestFlight/App Store
+        env:
+          IOS_KEY_PATH: ${{ env.IOS_KEY_PATH }}
+          IOS_IPA_PATH: ${{ env.IOS_IPA_PATH }}
+        run: |
+          fastlane ios upload description:'${{ github.event.inputs.body }}' isReleasing:${{ github.event.inputs.isReleasing }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,23 +1,13 @@
 # This file contains the fastlane.tools configuration
 # You can find the documentation at https://docs.fastlane.tools
-#
-# For a list of all available actions, check out
-#
-#     https://docs.fastlane.tools/actions
-#
-# For a list of all available plugins, check out
-#
-#     https://docs.fastlane.tools/plugins/available-plugins
-#
 
-# Uncomment the line if you want fastlane to automatically update itself
-# update_fastlane
+ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
 platform :ios do
   def loadiOSConfigs()
     @package_name = ENV["PACKAGE_NAME"]
-    @project_name = ENV["PRODUCT_NAME"]
-    @app_project_name = "App"
+    @workspace_name = ENV["PRODUCT_NAME"]
+    @project_name = "App"
     @keychain_name = ENV["IOS_KEYCHAIN"]
     @keychain_password = ENV["IOS_KEYCHAIN_PWD"]
     @certificate_path = ENV["IOS_CERT_PATH"]
@@ -26,11 +16,13 @@ platform :ios do
     @team_id = ENV["APPLE_TEAM_ID"]
     @api_key_path = ENV["IOS_KEY_PATH"]
     @xcodeproj = "./Projects/App/App.xcodeproj"
+    @profile_name = @workspace_name
+    @ipa_path = ENV["IOS_IPA_PATH"]
 
     puts "iOS 프로젝트: #{@project_name}]"
     puts "Fastlane 키파일 경로: #{@api_key_path}]"
   end
-  
+
   def installCert
     create_keychain(
         name: @keychain_name,
@@ -40,46 +32,39 @@ platform :ios do
         timeout: 3600,
         lock_when_sleeps: true,
     )
-  
+
     import_certificate(
         certificate_path: @certificate_path,
         certificate_password: @certificate_password,
         keychain_name: @keychain_name,
         keychain_password: @keychain_password,
     )
-    
+
     puts "iOS 인증서 설치"
   end
 
   def readySigning
     installCert()
-    
+
     install_provisioning_profile(
       path: @provisioning_profile_path
     )
     puts "Provisioning Profile 설치"
-    
-    #update_project_provisioning(
-    #  xcodeproj: @xcodeproj,
-    #  profile: @provisioning_profile_path
-    #)
-    #puts "Provisioning Profile 설정"
-    
+
     update_code_signing_settings(
       use_automatic_signing: false,
       path: @xcodeproj,
       team_id: @team_id,
-      code_sign_identity: "iPhone Distribution",
+      code_sign_identity: "Apple Distribution",
       profile_name: @profile_name
     )
     puts "Code Signing 수동으로 전환"
-
   end
 
   def setiOSVersions
     @app_version = get_version_number(
-       xcodeproj: @xcodeproj
-      #  target: 'App'
+       xcodeproj: @xcodeproj,
+       target: @project_name
     )
     puts "iOS 앱 버전: #{@app_version}"
 
@@ -89,7 +74,7 @@ platform :ios do
       app_identifier: @package_name,
       initial_build_number: 0
     )
-    
+
     @new_build_version = @build_version + 1
     increment_build_number(
       xcodeproj: @xcodeproj,
@@ -100,46 +85,40 @@ platform :ios do
     @full_app_verion = "#{@app_version}(#{@new_build_version})"
   end
 
-  def buildiOS(changelog: 'build from fastlane', isReleasing: false)
+  lane :setup do
     loadiOSConfigs()
     readySigning()
     setiOSVersions()
 
-    puts "iOS 빌드 시작: #{@full_app_verion}"
-    build_app(
-      workspace: "./#{@project_name}.xcworkspace",
-      scheme: @app_project_name,
-      skip_profile_detection: true,
-      export_options: {
-        provisioningProfiles: {
-          @package_name => "WhoCallMe Release",
-        }
-      },
-      silent: true
-    )
-    
+    puts "iOS 인증서 설치 및 버전 관리 완료"
+  end
+
+  lane :upload do |options|
+    loadiOSConfigs()
+
+    changelog = options[:description] || 'build from fastlane'
+    isReleasing = options[:isReleasing] || false
+
     if isReleasing
-        puts "iOS 심사 업로드 시작"
-        upload_to_app_store(
-          api_key_path: @api_key_path,
-          release_notes: changelog,
-          app_identifier: @package_name,
-          submit_for_review: true,
-        )
-        puts "iOS 심사 제출 완료"
+      puts "iOS 심사 업로드 시작"
+      upload_to_app_store(
+        ipa: @ipa_path,
+        api_key_path: @api_key_path,
+        release_notes: changelog,
+        app_identifier: @package_name,
+        submit_for_review: true,
+      )
+      puts "iOS 심사 제출 완료"
     else
-        puts "iOS TestFlight 업로드 시작"
-        upload_to_testflight(
-          api_key_path: @api_key_path,
-          changelog: changelog,
-          app_identifier: @package_name,
-        )
-        puts "iOS TestFlight 배포 완료"
+      puts "iOS TestFlight 업로드 시작"
+      upload_to_testflight(
+        ipa: @ipa_path,
+        api_key_path: @api_key_path,
+        changelog: changelog,
+        app_identifier: @package_name,
+        skip_waiting_for_build_processing: true
+      )
+      puts "iOS TestFlight 배포 완료"
     end
   end
-
-  lane :release do | options|
-    buildiOS(changelog: options[:description], isReleasing: options[:isReleasing])
-  end
 end
-


### PR DESCRIPTION
## Summary
- Upgrade runner to `macos-26` and Xcode 26.1.1
- Replace `brew install mise` with `jdx/mise-action@v2` (official, faster)
- Add missing `tuist generate` step; remove incorrect `tuist build` step
- Add `permissions: id-token: write`
- Move `PACKAGE_NAME` to top-level env
- Split build into separate archive (`tuist xcodebuild archive`) + export IPA steps
- Remove broken NSAppTransportSecurity step (referenced wrong path)
- Fastfile: split single `release` lane into `setup` + `upload` lanes
- Fastfile: fix `@profile_name` undefined variable bug
- Fastfile: `iPhone Distribution` → `Apple Distribution`
- Fastfile: add `target:` to `get_version_number`
- Fastfile: add `skip_waiting_for_build_processing: true` to TestFlight upload

## Test plan
- [ ] Trigger workflow with `isReleasing: false` → uploads to TestFlight
- [ ] Trigger workflow with `isReleasing: true` → submits for App Store review

🤖 Generated with [Claude Code](https://claude.com/claude-code)