### PR TITLE
feat: add settings banner ad

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -67,7 +67,8 @@ let project = Project(
                 "GADApplicationIdentifier": "ca-app-pub-9684378399371172~4206633246",
                 "GADUnitIdentifiers" : [
                     "FullAd" : "ca-app-pub-9684378399371172/4108901647",
-                    "HomeBanner" : "ca-app-pub-9684378399371172/2132640843"
+                    "HomeBanner" : "ca-app-pub-9684378399371172/2132640843",
+                    "SettingsBanner" : "ca-app-pub-9684378399371172/7926699548"
                 ],
                 "Itunes App Id": "395429781",
                 "NSContactsUsageDescription": "This app needs access contacts to convert",

--- a/Projects/App/Sources/Screens/SettingsScreen.swift
+++ b/Projects/App/Sources/Screens/SettingsScreen.swift
@@ -14,6 +14,7 @@ struct SettingsScreen: View {
     @AppStorage(LSDefaults.Keys.needPhotoContainsJob) private var needPhotoContainsJob = true
 
     var body: some View {
+        VStack(spacing: 0) {
         List {
             Section("SETTINGS_SECTION_CONTACTS") {
                 Toggle("SETTINGS_GENERATE_NICKNAME", isOn: $needGenerateNickname)
@@ -41,6 +42,9 @@ struct SettingsScreen: View {
         }
         .navigationTitle("SETTINGS_TITLE")
         .navigationBarTitleDisplayMode(.inline)
+
+        BannerAdView(unitName: .settingsBanner)
+        } // VStack
     }
 }
 

--- a/Projects/App/Sources/extensions/Ad/GADUnitName.swift
+++ b/Projects/App/Sources/extensions/Ad/GADUnitName.swift
@@ -1,11 +1,12 @@
 extension SwiftUIAdManager {
     enum GADUnitName: String {
-        case full       = "FullAd"
-        case homeBanner = "HomeBanner"
+        case full           = "FullAd"
+        case homeBanner     = "HomeBanner"
+        case settingsBanner = "SettingsBanner"
     }
 
 #if DEBUG
-    var testUnits: [GADUnitName] { [.full, .homeBanner] }
+    var testUnits: [GADUnitName] { [.full, .homeBanner, .settingsBanner] }
 #else
     var testUnits: [GADUnitName] { [] }
 #endif


### PR DESCRIPTION
## Summary
- Register `SettingsBanner` unit (`ca-app-pub-9684378399371172/7926699548`) in `Project.swift` `GADUnitIdentifiers`
- Add `GADUnitName.settingsBanner` case
- Place banner at the bottom of `SettingsScreen` (below the List)

> Note: depends on `feat/home-banner` (#7) for `BannerAdView`. Merge that first.

## Test plan
- [ x] Banner loads at bottom of Settings screen
- [ x] Banner collapses to height 0 when not ready

# Result
<img width="606" alt="Screenshot 2026-02-13 at 5 36 11 PM" src="https://github.com/user-attachments/assets/a36d36c0-183f-41c4-b53b-83c238a6272b" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)