### PR TITLE
feat: setup uploading dSYM Crashlytics

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -81,6 +81,20 @@ let project = Project(
             sources: ["Sources/**"],
             resources: ["Resources/**"],
             entitlements: .file(path: .relativeToCurrentFile("Sources/App.entitlements")),
+            scripts: [
+                .post(
+                    script: "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run",
+                    name: "Upload dSYM for Crashlytics",
+                    inputPaths: [
+                        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+                        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+                        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+                        "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+                        "$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)"
+                    ],
+                    runForInstallBuildsOnly: true
+                )
+            ],
             dependencies: [
                             
                            .Projects.ThirdParty,


### PR DESCRIPTION
## Summary
- Add Crashlytics dSYM upload post-build script to `Projects/App/Project.swift`
- Runs only on install builds (`runForInstallBuildsOnly: true`)
- Matches the pattern used in talktrans

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)