### PR TITLE
chore: migrate firebase-ios-sdk to Tuist registry

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -110,3 +110,20 @@ default_modes:
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []

--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -2,8 +2,7 @@ import ProjectDescription
 
 let project = Project(
     name: "DynamicThirdParty",
-    packages: [.remote(url: "https://github.com/firebase/firebase-ios-sdk",
-                       requirement: .upToNextMajor(from: "11.8.1")),
+    packages: [.package(id: "firebase.firebase-ios-sdk", from: "11.8.1"),
     ],
     targets: [
         .target(

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -8,10 +8,10 @@
 import ProjectDescription
 
 let tuist = Tuist(
-    project: .tuist(compatibleXcodeVersions: .upToNextMajor("26.0")
-//                    swiftVersion: "",
-//                    plugins: <#T##[PluginLocation]#>,
-//                    generationOptions: <#T##Tuist.GenerationOptions#>,
-//                    installOptions: <#T##Tuist.InstallOptions#>)
+    project: .tuist(
+        compatibleXcodeVersions: .upToNextMajor("26.0"),
+        generationOptions: .options(
+            registryEnabled: true
+        )
     )
 )


### PR DESCRIPTION
## Summary
- Enables `registryEnabled: true` in `Tuist.swift` to use the Tuist registry (Swift Package Index backend)
- Migrates `firebase/firebase-ios-sdk` from `.remote(url:)` to `.package(id: "firebase.firebase-ios-sdk", from: "11.8.1")` via the registry
- All other packages (`GADManager`, `StringLogger`, `LSExtensions`) are not available on the registry — kept as `.remote(url:)`

## Test plan
- [ ] `mise x -- tuist install && mise x -- tuist generate --no-open` succeeds cleanly
- [ ] Firebase dependencies (Crashlytics, Analytics, Messaging, RemoteConfig) resolve correctly
- [ ] App builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)