### PR TITLE
ci: add Build & Test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,53 @@
+name: "Build & Test"
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - '**/*.swift'
+      - 'mise.toml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '**/*.swift'
+      - 'mise.toml'
+
+jobs:
+  build-test:
+    name: Build & Test
+    runs-on: macos-26
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+      id-token: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Select Xcode
+      run: |
+        sudo xcode-select -s /Applications/Xcode_26.1.1.app
+
+    - name: Install Mise
+      uses: jdx/mise-action@v2
+
+    - name: Log in Tuist
+      run: |
+        tuist auth login
+
+    - name: Install Dependencies
+      run: |
+        tuist install
+
+    - name: Setup Tuist Cache Service
+      run: |
+        tuist setup cache
+
+    - name: Test App
+      env:
+        SCHEME: App
+      run: |
+        tuist test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-test.yml` mirrored from the wherewego project
- Triggers on push/PR to `main` when `.swift` or `mise.toml` files change
- Runs on `macos-26` with Xcode 26.1.1 via `jdx/mise-action@v2`
- Steps: Tuist auth login → install → setup cache → `tuist test`

## Test plan
- [ ] Workflow appears in GitHub Actions tab
- [ ] Triggered automatically on next Swift file change to main or PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)