### PR TITLE
fix: move xcconfig settings from project to App target

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -46,14 +46,6 @@ let project = Project(
         //        requirement: .upToNextMajor(from: "10.4.0")),
         
     ],
-    settings: .settings(configurations: [
-        .debug(
-            name: "Debug",
-            xcconfig: "Configs/app.debug.xcconfig"),
-        .release(
-            name: "Release",
-            xcconfig: "Configs/app.release.xcconfig")
-    ]),
     targets: [
         .target(
             name: "App",
@@ -61,7 +53,11 @@ let project = Project(
             product: .app,
             bundleId: "com.credif.who",
             deploymentTargets: .iOS("18.0"),
-        infoPlist: .extendingDefault(
+            settings: .settings(configurations: [
+                .debug(name: "Debug", xcconfig: "Configs/app.debug.xcconfig"),
+                .release(name: "Release", xcconfig: "Configs/app.release.xcconfig")
+            ]),
+            infoPlist: .extendingDefault(
             with: [
                 "UILaunchStoryboardName": "LaunchScreen",
                 "GADApplicationIdentifier": "ca-app-pub-9684378399371172~4206633246",

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -105,7 +105,8 @@ let project = Project(
             infoPlist: .default,
             sources: ["Tests/**"],
             resources: [],
-            dependencies: [.target(name: "App")]
+            dependencies: [.target(name: "App")],
+            settings: .settings(base: ["CODE_SIGNING_ALLOWED": "NO"])
         ),
     ]
 )

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -53,10 +53,6 @@ let project = Project(
             product: .app,
             bundleId: "com.credif.who",
             deploymentTargets: .iOS("18.0"),
-            settings: .settings(configurations: [
-                .debug(name: "Debug", xcconfig: "Configs/app.debug.xcconfig"),
-                .release(name: "Release", xcconfig: "Configs/app.release.xcconfig")
-            ]),
             infoPlist: .extendingDefault(
             with: [
                 "UILaunchStoryboardName": "LaunchScreen",
@@ -77,6 +73,10 @@ let project = Project(
             sources: ["Sources/**"],
             resources: ["Resources/**"],
             entitlements: .file(path: .relativeToCurrentFile("Sources/App.entitlements")),
+            settings: .settings(configurations: [
+                .debug(name: "Debug", xcconfig: "Configs/app.debug.xcconfig"),
+                .release(name: "Release", xcconfig: "Configs/app.release.xcconfig")
+            ]),
             scripts: [
                 .post(
                     script: "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run",

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -73,10 +73,6 @@ let project = Project(
             sources: ["Sources/**"],
             resources: ["Resources/**"],
             entitlements: .file(path: .relativeToCurrentFile("Sources/App.entitlements")),
-            settings: .settings(configurations: [
-                .debug(name: "Debug", xcconfig: "Configs/app.debug.xcconfig"),
-                .release(name: "Release", xcconfig: "Configs/app.release.xcconfig")
-            ]),
             scripts: [
                 .post(
                     script: "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run",
@@ -91,8 +87,12 @@ let project = Project(
                     runForInstallBuildsOnly: true
                 )
             ],
+            settings: .settings(configurations: [
+                .debug(name: "Debug", xcconfig: "Configs/app.debug.xcconfig"),
+                .release(name: "Release", xcconfig: "Configs/app.release.xcconfig")
+            ]),
             dependencies: [
-                            
+
                            .Projects.ThirdParty,
                            .Projects.DynamicThirdParty,
                            .package(product: "GADManager", type: .runtime)

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -87,16 +87,15 @@ let project = Project(
                     runForInstallBuildsOnly: true
                 )
             ],
-            settings: .settings(configurations: [
-                .debug(name: "Debug", xcconfig: "Configs/app.debug.xcconfig"),
-                .release(name: "Release", xcconfig: "Configs/app.release.xcconfig")
-            ]),
             dependencies: [
-
                            .Projects.ThirdParty,
                            .Projects.DynamicThirdParty,
                            .package(product: "GADManager", type: .runtime)
-            ]
+            ],
+            settings: .settings(configurations: [
+                .debug(name: "Debug", xcconfig: "Configs/app.debug.xcconfig"),
+                .release(name: "Release", xcconfig: "Configs/app.release.xcconfig")
+            ])
         ),
         .target(
             name: "AppTests",

--- a/Projects/App/Tests/WhoCallMeTests.swift
+++ b/Projects/App/Tests/WhoCallMeTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import WhoCallMe
+@testable import App
 
 class WhoCallMeTests: XCTestCase {
     


### PR DESCRIPTION
## Summary
- Move xcconfig settings from Project level to App target only
- AppTests was inheriting CODE_SIGN_ENTITLEMENTS from project-level xcconfig, causing a build failure since the entitlements file path does not exist in the test target context

## Test plan
- [ ] tuist generate succeeds
- [ ] xcodebuild test passes

Generated with Claude Code