### PR TITLE
Introduce and adopt the WhoCallMe design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+### Claude Code ###
+.remember/
+
 ### macOS ###
 # General
 .DS_Store

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -127,3 +127,22 @@ language_backend:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/Projects/App/Sources/DesignSystem.swift
+++ b/Projects/App/Sources/DesignSystem.swift
@@ -2,37 +2,48 @@ import SwiftUI
 
 // MARK: - Color Tokens
 // Design System v1.0 — paper · ink · signal amber
+// Light: warm paper canvas. Dark: deep night canvas.
 
 extension Color {
-    // Paper family — warm neutrals
+    // Adaptive surface — paper in light, night in dark
+    static let appBackground  = Color(adaptive: "#F6F1EA", dark: "#0F0E0C")
+    static let appSurface     = Color(adaptive: "#FFFFFF",  dark: "#1A1916")  // cards
+    static let appSurface2    = Color(adaptive: "#EFE8DE",  dark: "#26241F")  // ring track, dividers
+
+    // Adaptive text
+    static let appTextPrimary   = Color(adaptive: "#141414", dark: "#F3EEE4")
+    static let appTextSecondary = Color(adaptive: "#5C564D", dark: "#B8B0A3")
+    static let appTextTertiary  = Color(adaptive: "#8A8377", dark: "#5C564D")
+
+    // Paper family — raw light values (for always-light contexts)
     static let appPaper       = Color(hex: "#F6F1EA")
     static let appPaper0      = Color(hex: "#FBF7F0")
     static let appPaper2      = Color(hex: "#EFE8DE")
     static let appPaper3      = Color(hex: "#E6DDD0")
 
-    // Ink family — text & structure
+    // Ink family — raw dark values (for always-dark contexts)
     static let appInk         = Color(hex: "#141414")
     static let appInk80       = Color(hex: "#2A2824")
     static let appInk60       = Color(hex: "#5C564D")
     static let appInk40       = Color(hex: "#8A8377")
     static let appInk20       = Color(hex: "#B8B0A3")
 
-    // Signal amber — convert, ring, enriched badge only
+    // Signal amber — convert, ring, enriched badge only (same in both modes)
     static let appAmber       = Color(red: 0.9578, green: 0.6390, blue: 0.2948) // oklch(0.78 0.14 65)
     static let appAmberDeep   = Color(red: 0.8819, green: 0.4738, blue: 0.1053) // oklch(0.68 0.16 55)
-    static let appAmberSoft   = Color(hex: "#F0E7D4")                            // oklch(0.94 0.05 75)
+    static let appAmberSoft   = Color(hex: "#F0E7D4")
 
-    // Signal mint — safe affirmative (toggle on, restore)
+    // Signal mint — safe affirmative (same in both modes)
     static let appMint        = Color(red: 0.2944, green: 0.5936, blue: 0.4734) // oklch(0.62 0.09 165)
-    static let appMintLight   = Color(red: 0.4706, green: 0.8000, blue: 0.6431) // oklch(0.82 0.08 165)
+    static let appMintLight   = Color(red: 0.4706, green: 0.8000, blue: 0.6431)
 
-    // Night — dark canvas
+    // Night — raw dark values (for always-dark contexts like incoming-call preview)
     static let appNight       = Color(hex: "#0F0E0C")
     static let appNight1      = Color(hex: "#1A1916")
     static let appNight2      = Color(hex: "#26241F")
     static let appNightText   = Color(hex: "#F3EEE4")
 
-    // Legacy aliases kept for compatibility during migration
+    // Legacy aliases
     static let appOrange      = appAmber
     static let appTeal        = appMint
     static let appRingStart   = appAmber
@@ -47,6 +58,14 @@ private extension Color {
         let g = Double((v >> 8) & 0xFF) / 255
         let b = Double(v & 0xFF) / 255
         self.init(red: r, green: g, blue: b)
+    }
+
+    init(adaptive light: String, dark: String) {
+        self.init(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(Color(hex: dark))
+                : UIColor(Color(hex: light))
+        })
     }
 }
 

--- a/Projects/App/Sources/DesignSystem.swift
+++ b/Projects/App/Sources/DesignSystem.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+// MARK: - Color Tokens
+// Design System v1.0 — paper · ink · signal amber
+
+extension Color {
+    // Paper family — warm neutrals
+    static let appPaper       = Color(hex: "#F6F1EA")
+    static let appPaper0      = Color(hex: "#FBF7F0")
+    static let appPaper2      = Color(hex: "#EFE8DE")
+    static let appPaper3      = Color(hex: "#E6DDD0")
+
+    // Ink family — text & structure
+    static let appInk         = Color(hex: "#141414")
+    static let appInk80       = Color(hex: "#2A2824")
+    static let appInk60       = Color(hex: "#5C564D")
+    static let appInk40       = Color(hex: "#8A8377")
+    static let appInk20       = Color(hex: "#B8B0A3")
+
+    // Signal amber — convert, ring, enriched badge only
+    static let appAmber       = Color(red: 0.9578, green: 0.6390, blue: 0.2948) // oklch(0.78 0.14 65)
+    static let appAmberDeep   = Color(red: 0.8819, green: 0.4738, blue: 0.1053) // oklch(0.68 0.16 55)
+    static let appAmberSoft   = Color(hex: "#F0E7D4")                            // oklch(0.94 0.05 75)
+
+    // Signal mint — safe affirmative (toggle on, restore)
+    static let appMint        = Color(red: 0.2944, green: 0.5936, blue: 0.4734) // oklch(0.62 0.09 165)
+    static let appMintLight   = Color(red: 0.4706, green: 0.8000, blue: 0.6431) // oklch(0.82 0.08 165)
+
+    // Night — dark canvas
+    static let appNight       = Color(hex: "#0F0E0C")
+    static let appNight1      = Color(hex: "#1A1916")
+    static let appNight2      = Color(hex: "#26241F")
+    static let appNightText   = Color(hex: "#F3EEE4")
+
+    // Legacy aliases kept for compatibility during migration
+    static let appOrange      = appAmber
+    static let appTeal        = appMint
+    static let appRingStart   = appAmber
+    static let appRingEnd     = appAmberDeep
+}
+
+private extension Color {
+    init(hex: String) {
+        let h = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        let v = UInt64(h, radix: 16) ?? 0
+        let r = Double((v >> 16) & 0xFF) / 255
+        let g = Double((v >> 8) & 0xFF) / 255
+        let b = Double(v & 0xFF) / 255
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+// MARK: - Typography Modifiers
+
+struct AppDisplayStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 88, weight: .bold, design: .default))
+            .fontDesign(.default)
+            .monospacedDigit()
+            .tracking(-88 * 0.035)
+    }
+}
+
+struct AppTitleStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 56, weight: .semibold))
+            .tracking(-56 * 0.025)
+    }
+}
+
+struct AppSectionStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 32, weight: .semibold))
+            .tracking(-32 * 0.02)
+    }
+}
+
+struct AppSubStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 22, weight: .medium))
+            .tracking(-22 * 0.01)
+    }
+}
+
+struct AppBodyStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content.font(.system(size: 17, weight: .regular))
+    }
+}
+
+struct AppCaptionStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content.font(.system(size: 14, weight: .regular))
+    }
+}
+
+struct AppEyebrowStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 13, weight: .medium, design: .monospaced))
+            .tracking(13 * 0.14)
+            .textCase(.uppercase)
+    }
+}
+
+extension View {
+    func appDisplay()  -> some View { modifier(AppDisplayStyle()) }
+    func appTitle()    -> some View { modifier(AppTitleStyle()) }
+    func appSection()  -> some View { modifier(AppSectionStyle()) }
+    func appSub()      -> some View { modifier(AppSubStyle()) }
+    func appBody()     -> some View { modifier(AppBodyStyle()) }
+    func appCaption()  -> some View { modifier(AppCaptionStyle()) }
+    func appEyebrow()  -> some View { modifier(AppEyebrowStyle()) }
+}
+
+// MARK: - Spacing
+
+extension CGFloat {
+    static let sp2xs: CGFloat = 4
+    static let spXS:  CGFloat = 8
+    static let spSM:  CGFloat = 12
+    static let spMD:  CGFloat = 16
+    static let spLG:  CGFloat = 24
+    static let spXL:  CGFloat = 32
+    static let sp2XL: CGFloat = 48
+    static let sp3XL: CGFloat = 64
+}
+
+// MARK: - Corner Radius
+
+extension CGFloat {
+    static let radiusSM:   CGFloat = 8
+    static let radiusMD:   CGFloat = 14
+    static let radiusLG:   CGFloat = 20
+    static let radiusXL:   CGFloat = 28
+}
+
+// MARK: - Animation Tokens
+
+extension Animation {
+    static let appTap:    Animation = .easeOut(duration: 0.12)
+    static let appEase:   Animation = .easeInOut(duration: 0.24)
+    static let appRing:   Animation = .easeInOut(duration: 0.4)
+    static let appSpring: Animation = .spring(response: 0.4, dampingFraction: 0.75)
+}
+
+// MARK: - Gradient Helpers
+
+extension LinearGradient {
+    static var appAmberGradient: LinearGradient {
+        LinearGradient(
+            colors: [Color.appAmber, Color.appAmberDeep],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    static var appAmberGradientH: LinearGradient {
+        LinearGradient(
+            colors: [Color.appAmber, Color.appAmberDeep],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    }
+}

--- a/Projects/App/Sources/DesignSystem.swift
+++ b/Projects/App/Sources/DesignSystem.swift
@@ -15,6 +15,14 @@ extension Color {
     static let appTextSecondary = Color(adaptive: "#5C564D", dark: "#B8B0A3")
     static let appTextTertiary  = Color(adaptive: "#8A8377", dark: "#5C564D")
 
+    // Semantic tokens
+    static let appSuccess       = appMint
+    static let appDestructive   = Color(adaptive: "#E64545", dark: "#EF5A5A")
+    static let appDestructiveDeep = Color(adaptive: "#C72E2E", dark: "#D84545")
+    static let appDisabled      = Color(adaptive: "#C7C0B4", dark: "#3C3832")
+    static let appSeparator     = Color(adaptive: "#E6DDD0", dark: "#2F2C26")
+    static let appBorder        = Color(adaptive: "#DDD3C5", dark: "#3A362F")
+
     // Paper family — raw light values (for always-light contexts)
     static let appPaper       = Color(hex: "#F6F1EA")
     static let appPaper0      = Color(hex: "#FBF7F0")
@@ -184,5 +192,137 @@ extension LinearGradient {
             startPoint: .leading,
             endPoint: .trailing
         )
+    }
+
+    static var appDestructiveGradient: LinearGradient {
+        LinearGradient(
+            colors: [Color.appDestructive, Color.appDestructiveDeep],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+}
+
+// MARK: - Reusable Components / Styles
+
+enum AppButtonTone {
+    case primary
+    case destructive
+}
+
+struct AppCapsuleButtonStyle: ButtonStyle {
+    let tone: AppButtonTone
+    let foreground: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundStyle(foreground)
+            .frame(maxWidth: .infinity, minHeight: 56)
+            .background(
+                tone == .destructive
+                    ? LinearGradient.appDestructiveGradient
+                    : LinearGradient.appAmberGradient
+            )
+            .clipShape(Capsule())
+            .shadow(
+                color: (tone == .destructive ? Color.appDestructive : Color.appAmberDeep)
+                    .opacity(configuration.isPressed ? 0.2 : 0.35),
+                radius: configuration.isPressed ? 8 : 12,
+                y: configuration.isPressed ? 3 : 6
+            )
+            .scaleEffect(configuration.isPressed ? 0.995 : 1)
+            .animation(.appTap, value: configuration.isPressed)
+    }
+}
+
+struct AppCardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: .radiusLG, style: .continuous)
+                    .fill(Color.appSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: .radiusLG, style: .continuous)
+                            .stroke(Color.appBorder, lineWidth: 1)
+                    )
+                    .shadow(color: Color.appInk.opacity(0.06), radius: 12, y: 4)
+            )
+    }
+}
+
+extension View {
+    func appCard() -> some View {
+        modifier(AppCardStyle())
+    }
+}
+
+struct AppIconBadge: View {
+    let systemImage: String
+    let backgroundColor: Color?
+    let foreground: Color
+
+    init(
+        systemImage: String,
+        backgroundColor: Color? = nil,
+        foreground: Color = .appInk
+    ) {
+        self.systemImage = systemImage
+        self.backgroundColor = backgroundColor
+        self.foreground = foreground
+    }
+
+    var body: some View {
+        ZStack {
+            if let backgroundColor {
+                RoundedRectangle(cornerRadius: .radiusSM, style: .continuous)
+                    .fill(backgroundColor)
+            } else {
+                RoundedRectangle(cornerRadius: .radiusSM, style: .continuous)
+                    .fill(LinearGradient.appAmberGradient)
+            }
+
+            Image(systemName: systemImage)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(foreground)
+        }
+        .frame(width: 32, height: 32)
+    }
+}
+
+struct AppActionRow: View {
+    let title: LocalizedStringKey
+    let icon: String
+    let iconBackgroundColor: Color?
+    let iconForeground: Color
+
+    init(
+        title: LocalizedStringKey,
+        icon: String,
+        iconBackgroundColor: Color? = nil,
+        iconForeground: Color = .appInk
+    ) {
+        self.title = title
+        self.icon = icon
+        self.iconBackgroundColor = iconBackgroundColor
+        self.iconForeground = iconForeground
+    }
+
+    var body: some View {
+        HStack(spacing: .spMD) {
+            AppIconBadge(
+                systemImage: icon,
+                backgroundColor: iconBackgroundColor,
+                foreground: iconForeground
+            )
+            Text(title)
+                .appBody()
+                .foregroundStyle(Color.appTextPrimary)
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.appTextTertiary)
+        }
+        .padding(.horizontal, .spMD)
+        .frame(height: 52)
     }
 }

--- a/Projects/App/Sources/Preview/ContactDeptCell.swift
+++ b/Projects/App/Sources/Preview/ContactDeptCell.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 class ContactDeptCell: UITableViewCell {
 
@@ -15,7 +16,11 @@ class ContactDeptCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+        self.selectionStyle = .none
+        self.backgroundColor = .clear
+        self.contentView.backgroundColor = .clear
+        self.titleLabel?.textColor = UIColor(Color.appNightText)
+        self.valueLabel?.textColor = UIColor(Color.appNightText)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/Projects/App/Sources/Preview/ContactImageCell.swift
+++ b/Projects/App/Sources/Preview/ContactImageCell.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 class ContactImageCell: UITableViewCell {
 
@@ -14,7 +15,10 @@ class ContactImageCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+        self.selectionStyle = .none
+        self.backgroundColor = .clear
+        self.contentView.backgroundColor = .clear
+        self.contactImage.tintColor = UIColor(Color.appNightText)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/Projects/App/Sources/Preview/ContactJobCell.swift
+++ b/Projects/App/Sources/Preview/ContactJobCell.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 class ContactJobCell: UITableViewCell {
 
@@ -15,7 +16,11 @@ class ContactJobCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+        self.selectionStyle = .none
+        self.backgroundColor = .clear
+        self.contentView.backgroundColor = .clear
+        self.titleLabel?.textColor = UIColor(Color.appNightText)
+        self.valueLabel?.textColor = UIColor(Color.appNightText)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/Projects/App/Sources/Preview/ContactOrgCell.swift
+++ b/Projects/App/Sources/Preview/ContactOrgCell.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 class ContactOrgCell: UITableViewCell {
 
@@ -15,7 +16,11 @@ class ContactOrgCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+        self.selectionStyle = .none
+        self.backgroundColor = .clear
+        self.contentView.backgroundColor = .clear
+        self.titleLabel?.textColor = UIColor(Color.appNightText)
+        self.valueLabel?.textColor = UIColor(Color.appNightText)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/Projects/App/Sources/Preview/ContactTemplateViewController.swift
+++ b/Projects/App/Sources/Preview/ContactTemplateViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import Contacts
 import FirebaseAnalytics
+import SwiftUI
 
 /**
     view controller to create and preview call receive image
@@ -82,6 +83,8 @@ class ContactTemplateViewController: UIViewController, UITableViewDataSource, UI
         // Makes navigationbar transparent
         self.navigationController?.navigationBar.shadowImage = UIImage();
         self.navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default);
+
+        self.applyDesignSystemAppearance();
 
         self.isPreviewMode = Bool(self.isPreviewMode);
         self.refreshName();
@@ -168,6 +171,23 @@ class ContactTemplateViewController: UIViewController, UITableViewDataSource, UI
     fileprivate func refreshName(){
         if self.isPreviewMode {
             self.lb_name?.text = self.contact?.fullName;
+        }
+    }
+
+    fileprivate func applyDesignSystemAppearance() {
+        self.view?.backgroundColor = UIColor(Color.appNight);
+        self.infoTable?.backgroundColor = UIColor(Color.appNight2).withAlphaComponent(0.22);
+        self.lb_name?.textColor = UIColor(Color.appNightText);
+        self.lb_status?.textColor = UIColor(Color.appNightText);
+        self.darkCoverView?.backgroundColor = UIColor(Color.appNight).withAlphaComponent(0.20);
+
+        if let commands = self.callCommandView?.subviews {
+            if commands.indices.contains(0) {
+                commands[0].backgroundColor = UIColor(Color.appDestructive);
+            }
+            if commands.indices.contains(1) {
+                commands[1].backgroundColor = UIColor(Color.appSuccess);
+            }
         }
     }
 

--- a/Projects/App/Sources/Screens/MainScreen.swift
+++ b/Projects/App/Sources/Screens/MainScreen.swift
@@ -70,19 +70,19 @@ struct MainScreen: View {
 
             VStack(spacing: 0) {
                 headerBar
-                    .padding(.horizontal, 16)
-                    .padding(.top, 12)
+                    .padding(.horizontal, .spMD)
+                    .padding(.top, .spSM)
                     .padding(.bottom, 10)
 
                 Spacer()
 
-                VStack(spacing: 24) {
+                VStack(spacing: .spLG) {
                     ZStack {
                         RingProgressView(progress: progress)
                             .frame(width: 240, height: 240)
                             .shadow(color: Color.appAmberDeep.opacity(0.25), radius: 20)
 
-                        VStack(spacing: 4) {
+                        VStack(spacing: .sp2xs) {
                             Text("\(progressedCount)")
                                 .font(.system(size: 80, weight: .thin))
                                 .monospacedDigit()
@@ -96,19 +96,19 @@ struct MainScreen: View {
                     }
 
                     convertAllButton
-                        .padding(.horizontal, 16)
+                        .padding(.horizontal, .spMD)
                 }
 
                 Spacer()
 
                 actionsCard
-                    .padding(.horizontal, 16)
+                    .padding(.horizontal, .spMD)
 
                 Spacer()
 
                 bottomBar
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 8)
+                    .padding(.horizontal, .spMD)
+                    .padding(.bottom, .spXS)
 
                 BannerAdView(unitName: .homeBanner)
             }
@@ -191,12 +191,12 @@ struct MainScreen: View {
     // MARK: - Subviews
 
     private var headerBar: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: .spSM) {
             if let icon = Bundle.main.appIcon {
                 Image(uiImage: icon)
                     .resizable()
                     .frame(width: 36, height: 36)
-                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: .radiusSM, style: .continuous))
             }
             Text("MAIN_APP_TITLE")
                 .font(.title3.bold())
@@ -212,7 +212,7 @@ struct MainScreen: View {
                     .background(.regularMaterial)
                     .clipShape(Capsule())
             }
-            .foregroundStyle(.primary)
+            .foregroundStyle(Color.appTextPrimary)
         }
     }
 
@@ -224,30 +224,20 @@ struct MainScreen: View {
                 showConvertConfirm = true
             }
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: .spXS) {
                 Image(systemName: isRunning ? "stop.fill" : "arrow.2.squarepath")
                     .font(.body.weight(.semibold))
                 Text(isRunning ? NSLocalizedString("STOP", comment: "") : NSLocalizedString("MAIN_CONVERT", comment: ""))
-                    .font(.system(size: 17, weight: .semibold))
+                    .appBody()
+                    .fontWeight(.semibold)
             }
-            .foregroundStyle(isRunning ? Color.white : Color(red: 0.10, green: 0.07, blue: 0.03))
-            .frame(maxWidth: .infinity, minHeight: 56)
-            .background(
-                LinearGradient(
-                    colors: isRunning
-                        ? [Color(red: 1.0, green: 0.22, blue: 0.22), Color(red: 0.85, green: 0.10, blue: 0.10)]
-                        : [Color.appAmber, Color.appAmberDeep],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
-            .clipShape(Capsule())
-            .shadow(
-                color: (isRunning ? Color.red : Color.appAmberDeep).opacity(0.35),
-                radius: 12,
-                y: 6
-            )
         }
+        .buttonStyle(
+            AppCapsuleButtonStyle(
+                tone: isRunning ? .destructive : .primary,
+                foreground: isRunning ? .appNightText : .appInk
+            )
+        )
         .animation(.appEase, value: isRunning)
     }
 
@@ -257,63 +247,31 @@ struct MainScreen: View {
                 contactPickerMode = .convertOne
                 isShowingContactPicker = true
             } label: {
-                HStack(spacing: .spMD) {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: .radiusSM, style: .continuous)
-                            .fill(LinearGradient.appAmberGradient)
-                            .frame(width: 32, height: 32)
-                        Image(systemName: "arrow.2.squarepath")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(Color(red: 0.10, green: 0.07, blue: 0.03))
-                    }
-                    Text("MAIN_CONVERT_ONE")
-                        .appBody()
-                        .foregroundStyle(Color.appTextPrimary)
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color.appTextTertiary)
-                }
-                .padding(.horizontal, .spMD)
-                .frame(height: 52)
+                AppActionRow(title: "MAIN_CONVERT_ONE", icon: "arrow.2.squarepath")
             }
             .disabled(isRunning)
 
             Divider()
                 .padding(.leading, 62)
-                .foregroundStyle(Color.appPaper2)
+                .foregroundStyle(Color.appSeparator)
 
             NavigationLink(destination: SettingsScreen()) {
-                HStack(spacing: .spMD) {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: .radiusSM, style: .continuous)
-                            .fill(Color.appTextSecondary)
-                            .frame(width: 32, height: 32)
-                        Image(systemName: "gearshape.fill")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(Color.appBackground)
-                    }
-                    Text("SETTINGS_TITLE")
-                        .appBody()
-                        .foregroundStyle(Color.appTextPrimary)
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color.appTextTertiary)
-                }
-                .padding(.horizontal, .spMD)
-                .frame(height: 52)
+                AppActionRow(
+                    title: "SETTINGS_TITLE",
+                    icon: "gearshape.fill",
+                    iconBackgroundColor: .appTextSecondary,
+                    iconForeground: .appBackground
+                )
             }
         }
-        .background(
-            RoundedRectangle(cornerRadius: .radiusLG, style: .continuous)
-                .fill(Color.appSurface)
-                .shadow(color: Color.appInk.opacity(0.06), radius: 12, y: 4)
-        )
+        .appCard()
     }
 
     private var bottomBar: some View {
         HStack(spacing: .spSM) {
+            let restoreDisabled = isRunning && mode != .restoreAll
+            let clearDisabled = isRunning && mode != .clearAll
+
             Button {
                 if isRunning && mode == .restoreAll {
                     operationState = .stopped
@@ -328,14 +286,18 @@ struct MainScreen: View {
                         .appCaption()
                         .fontWeight(.semibold)
                 }
-                .foregroundStyle(Color.appMint)
+                .foregroundStyle(restoreDisabled ? Color.appDisabled : Color.appSuccess)
                 .frame(maxWidth: .infinity, minHeight: 60)
                 .background(
                     RoundedRectangle(cornerRadius: .radiusMD, style: .continuous)
                         .fill(Color.appSurface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: .radiusMD, style: .continuous)
+                                .stroke(Color.appBorder, lineWidth: 1)
+                        )
                 )
             }
-            .disabled(isRunning && mode != .restoreAll)
+            .disabled(restoreDisabled)
 
             Button {
                 if isRunning && mode == .clearAll {
@@ -351,14 +313,18 @@ struct MainScreen: View {
                         .appCaption()
                         .fontWeight(.semibold)
                 }
-                .foregroundStyle(Color.appTextSecondary)
+                .foregroundStyle(clearDisabled ? Color.appDisabled : Color.appTextSecondary)
                 .frame(maxWidth: .infinity, minHeight: 60)
                 .background(
                     RoundedRectangle(cornerRadius: .radiusMD, style: .continuous)
                         .fill(Color.appSurface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: .radiusMD, style: .continuous)
+                                .stroke(Color.appBorder, lineWidth: 1)
+                        )
                 )
             }
-            .disabled(isRunning && mode != .clearAll)
+            .disabled(clearDisabled)
         }
     }
 
@@ -508,4 +474,3 @@ private extension Bundle {
         return UIImage(named: name)
     }
 }
-

--- a/Projects/App/Sources/Screens/MainScreen.swift
+++ b/Projects/App/Sources/Screens/MainScreen.swift
@@ -56,12 +56,11 @@ struct MainScreen: View {
 
     var body: some View {
         ZStack {
-            Color(.systemGroupedBackground)
+            Color.appPaper
                 .ignoresSafeArea()
 
-            // Ambient glow behind ring
             RadialGradient(
-                colors: [Color.appRingEnd.opacity(0.15), Color.clear],
+                colors: [Color.appAmberDeep.opacity(0.12), Color.clear],
                 center: .center,
                 startRadius: 60,
                 endRadius: 200
@@ -81,15 +80,17 @@ struct MainScreen: View {
                     ZStack {
                         RingProgressView(progress: progress)
                             .frame(width: 240, height: 240)
-                            .shadow(color: Color.appRingEnd.opacity(0.3), radius: 20)
+                            .shadow(color: Color.appAmberDeep.opacity(0.25), radius: 20)
 
                         VStack(spacing: 4) {
                             Text("\(progressedCount)")
-                                .font(.system(size: 72, weight: .thin, design: .rounded))
+                                .font(.system(size: 80, weight: .thin))
+                                .monospacedDigit()
+                                .foregroundStyle(Color.appInk)
                             if !statusText.isEmpty {
                                 Text(statusText)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .appEyebrow()
+                                    .foregroundStyle(Color.appInk40)
                             }
                         }
                     }
@@ -227,27 +228,27 @@ struct MainScreen: View {
                 Image(systemName: isRunning ? "stop.fill" : "arrow.2.squarepath")
                     .font(.body.weight(.semibold))
                 Text(isRunning ? NSLocalizedString("STOP", comment: "") : NSLocalizedString("MAIN_CONVERT", comment: ""))
-                    .font(.title3.weight(.semibold))
+                    .font(.system(size: 17, weight: .semibold))
             }
-            .foregroundStyle(.white)
+            .foregroundStyle(isRunning ? Color.white : Color(red: 0.10, green: 0.07, blue: 0.03))
             .frame(maxWidth: .infinity, minHeight: 56)
             .background(
                 LinearGradient(
                     colors: isRunning
                         ? [Color(red: 1.0, green: 0.22, blue: 0.22), Color(red: 0.85, green: 0.10, blue: 0.10)]
-                        : [Color.appOrange, Color(red: 1.0, green: 0.45, blue: 0.0)],
-                    startPoint: .leading,
-                    endPoint: .trailing
+                        : [Color.appAmber, Color.appAmberDeep],
+                    startPoint: .top,
+                    endPoint: .bottom
                 )
             )
-            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .clipShape(Capsule())
             .shadow(
-                color: (isRunning ? Color.red : Color.appOrange).opacity(0.35),
+                color: (isRunning ? Color.red : Color.appAmberDeep).opacity(0.35),
                 radius: 12,
                 y: 6
             )
         }
-        .animation(.easeInOut(duration: 0.2), value: isRunning)
+        .animation(.appEase, value: isRunning)
     }
 
     private var actionsCard: some View {
@@ -256,65 +257,63 @@ struct MainScreen: View {
                 contactPickerMode = .convertOne
                 isShowingContactPicker = true
             } label: {
-                HStack(spacing: 14) {
+                HStack(spacing: .spMD) {
                     ZStack {
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(LinearGradient(
-                                colors: [Color.appOrange, Color(red: 1.0, green: 0.45, blue: 0.0)],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            ))
+                        RoundedRectangle(cornerRadius: .radiusSM, style: .continuous)
+                            .fill(LinearGradient.appAmberGradient)
                             .frame(width: 32, height: 32)
                         Image(systemName: "arrow.2.squarepath")
                             .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(.white)
+                            .foregroundStyle(Color(red: 0.10, green: 0.07, blue: 0.03))
                     }
                     Text("MAIN_CONVERT_ONE")
-                        .font(.body)
-                        .foregroundStyle(.primary)
+                        .appBody()
+                        .foregroundStyle(Color.appInk)
                     Spacer()
                     Image(systemName: "chevron.right")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color(.tertiaryLabel))
+                        .foregroundStyle(Color.appInk40)
                 }
-                .padding(.horizontal, 16)
+                .padding(.horizontal, .spMD)
                 .frame(height: 52)
             }
             .disabled(isRunning)
 
             Divider()
                 .padding(.leading, 62)
+                .foregroundStyle(Color.appPaper2)
 
             NavigationLink(destination: SettingsScreen()) {
-                HStack(spacing: 14) {
+                HStack(spacing: .spMD) {
                     ZStack {
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(Color(.systemGray))
+                        RoundedRectangle(cornerRadius: .radiusSM, style: .continuous)
+                            .fill(Color.appInk60)
                             .frame(width: 32, height: 32)
                         Image(systemName: "gearshape.fill")
                             .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(.white)
+                            .foregroundStyle(Color.appPaper)
                     }
                     Text("SETTINGS_TITLE")
-                        .font(.body)
-                        .foregroundStyle(.primary)
+                        .appBody()
+                        .foregroundStyle(Color.appInk)
                     Spacer()
                     Image(systemName: "chevron.right")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color(.tertiaryLabel))
+                        .foregroundStyle(Color.appInk40)
                 }
-                .padding(.horizontal, 16)
+                .padding(.horizontal, .spMD)
                 .frame(height: 52)
             }
         }
         .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color(.secondarySystemGroupedBackground))
+            RoundedRectangle(cornerRadius: .radiusLG, style: .continuous)
+                .fill(Color.white)
+                .shadow(color: Color.appInk.opacity(0.06), radius: 12, y: 4)
         )
     }
 
     private var bottomBar: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: .spSM) {
             Button {
                 if isRunning && mode == .restoreAll {
                     operationState = .stopped
@@ -326,13 +325,14 @@ struct MainScreen: View {
                     Image(systemName: "arrow.uturn.backward")
                         .font(.title3)
                     Text("MAIN_RESTORE")
-                        .font(.caption.weight(.semibold))
+                        .appCaption()
+                        .fontWeight(.semibold)
                 }
-                .foregroundStyle(Color.appTeal)
+                .foregroundStyle(Color.appMint)
                 .frame(maxWidth: .infinity, minHeight: 60)
                 .background(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .fill(Color.appTeal.opacity(0.12))
+                    RoundedRectangle(cornerRadius: .radiusMD, style: .continuous)
+                        .fill(Color.appMint.opacity(0.10))
                 )
             }
             .disabled(isRunning && mode != .restoreAll)
@@ -348,13 +348,14 @@ struct MainScreen: View {
                     Image(systemName: "trash")
                         .font(.title3)
                     Text("MAIN_CLEAR_PHOTOS")
-                        .font(.caption.weight(.semibold))
+                        .appCaption()
+                        .fontWeight(.semibold)
                 }
-                .foregroundStyle(Color(.secondaryLabel))
+                .foregroundStyle(Color.appInk60)
                 .frame(maxWidth: .infinity, minHeight: 60)
                 .background(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .fill(Color(.secondarySystemGroupedBackground))
+                    RoundedRectangle(cornerRadius: .radiusMD, style: .continuous)
+                        .fill(Color.white.opacity(0.7))
                 )
             }
             .disabled(isRunning && mode != .clearAll)
@@ -472,23 +473,23 @@ private struct RingProgressView: View {
     var body: some View {
         ZStack {
             Circle()
-                .stroke(Color(.systemFill), lineWidth: 20)
+                .stroke(Color.appPaper2, lineWidth: 20)
 
             Circle()
                 .trim(from: 0, to: progress)
                 .stroke(
                     LinearGradient(
-                        colors: [Color.appRingStart, Color.appRingEnd],
+                        colors: [Color.appAmber, Color.appAmberDeep],
                         startPoint: .leading,
                         endPoint: .trailing
                     ),
                     style: StrokeStyle(lineWidth: 20, lineCap: .round)
                 )
                 .rotationEffect(.degrees(-90))
-                .animation(.easeInOut(duration: 0.4), value: progress)
+                .animation(.appRing, value: progress)
 
             Circle()
-                .fill(Color(.systemGroupedBackground))
+                .fill(Color.appPaper)
                 .padding(11)
         }
     }
@@ -508,11 +509,3 @@ private extension Bundle {
     }
 }
 
-// MARK: - App Colors
-
-extension Color {
-    static let appOrange = Color(red: 1.0, green: 0.72, blue: 0.0)
-    static let appTeal = Color(red: 0.13, green: 0.70, blue: 0.67)
-    static let appRingStart = Color(red: 0.10, green: 0.35, blue: 0.85)
-    static let appRingEnd = Color(red: 0.40, green: 0.65, blue: 1.0)
-}

--- a/Projects/App/Sources/Screens/MainScreen.swift
+++ b/Projects/App/Sources/Screens/MainScreen.swift
@@ -56,7 +56,7 @@ struct MainScreen: View {
 
     var body: some View {
         ZStack {
-            Color.appPaper
+            Color.appBackground
                 .ignoresSafeArea()
 
             RadialGradient(
@@ -86,11 +86,11 @@ struct MainScreen: View {
                             Text("\(progressedCount)")
                                 .font(.system(size: 80, weight: .thin))
                                 .monospacedDigit()
-                                .foregroundStyle(Color.appInk)
+                                .foregroundStyle(Color.appTextPrimary)
                             if !statusText.isEmpty {
                                 Text(statusText)
                                     .appEyebrow()
-                                    .foregroundStyle(Color.appInk40)
+                                    .foregroundStyle(Color.appTextTertiary)
                             }
                         }
                     }
@@ -268,11 +268,11 @@ struct MainScreen: View {
                     }
                     Text("MAIN_CONVERT_ONE")
                         .appBody()
-                        .foregroundStyle(Color.appInk)
+                        .foregroundStyle(Color.appTextPrimary)
                     Spacer()
                     Image(systemName: "chevron.right")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color.appInk40)
+                        .foregroundStyle(Color.appTextTertiary)
                 }
                 .padding(.horizontal, .spMD)
                 .frame(height: 52)
@@ -287,19 +287,19 @@ struct MainScreen: View {
                 HStack(spacing: .spMD) {
                     ZStack {
                         RoundedRectangle(cornerRadius: .radiusSM, style: .continuous)
-                            .fill(Color.appInk60)
+                            .fill(Color.appTextSecondary)
                             .frame(width: 32, height: 32)
                         Image(systemName: "gearshape.fill")
                             .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(Color.appPaper)
+                            .foregroundStyle(Color.appBackground)
                     }
                     Text("SETTINGS_TITLE")
                         .appBody()
-                        .foregroundStyle(Color.appInk)
+                        .foregroundStyle(Color.appTextPrimary)
                     Spacer()
                     Image(systemName: "chevron.right")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color.appInk40)
+                        .foregroundStyle(Color.appTextTertiary)
                 }
                 .padding(.horizontal, .spMD)
                 .frame(height: 52)
@@ -307,7 +307,7 @@ struct MainScreen: View {
         }
         .background(
             RoundedRectangle(cornerRadius: .radiusLG, style: .continuous)
-                .fill(Color.white)
+                .fill(Color.appSurface)
                 .shadow(color: Color.appInk.opacity(0.06), radius: 12, y: 4)
         )
     }
@@ -332,7 +332,7 @@ struct MainScreen: View {
                 .frame(maxWidth: .infinity, minHeight: 60)
                 .background(
                     RoundedRectangle(cornerRadius: .radiusMD, style: .continuous)
-                        .fill(Color.appMint.opacity(0.10))
+                        .fill(Color.appSurface)
                 )
             }
             .disabled(isRunning && mode != .restoreAll)
@@ -351,11 +351,11 @@ struct MainScreen: View {
                         .appCaption()
                         .fontWeight(.semibold)
                 }
-                .foregroundStyle(Color.appInk60)
+                .foregroundStyle(Color.appTextSecondary)
                 .frame(maxWidth: .infinity, minHeight: 60)
                 .background(
                     RoundedRectangle(cornerRadius: .radiusMD, style: .continuous)
-                        .fill(Color.white.opacity(0.7))
+                        .fill(Color.appSurface)
                 )
             }
             .disabled(isRunning && mode != .clearAll)
@@ -473,7 +473,7 @@ private struct RingProgressView: View {
     var body: some View {
         ZStack {
             Circle()
-                .stroke(Color.appPaper2, lineWidth: 20)
+                .stroke(Color.appSurface2, lineWidth: 20)
 
             Circle()
                 .trim(from: 0, to: progress)
@@ -489,7 +489,7 @@ private struct RingProgressView: View {
                 .animation(.appRing, value: progress)
 
             Circle()
-                .fill(Color.appPaper)
+                .fill(Color.appBackground)
                 .padding(11)
         }
     }

--- a/Projects/App/Sources/Screens/SettingsScreen.swift
+++ b/Projects/App/Sources/Screens/SettingsScreen.swift
@@ -14,37 +14,79 @@ struct SettingsScreen: View {
     @AppStorage(LSDefaults.Keys.needPhotoContainsJob) private var needPhotoContainsJob = true
 
     var body: some View {
-        VStack(spacing: 0) {
-        List {
-            Section("SETTINGS_SECTION_CONTACTS") {
-                Toggle("SETTINGS_GENERATE_NICKNAME", isOn: $needGenerateNickname)
-                Toggle("SETTINGS_INCLUDE_COMPANY", isOn: $needContainsOrg)
-                Toggle("SETTINGS_INCLUDE_DEPARTMENT", isOn: $needContainsDept)
-                Toggle("SETTINGS_INCLUDE_JOB_TITLE", isOn: $needContainsJob)
-                Toggle("SETTINGS_KOREAN_CONSONANT_SEARCH", isOn: $needMakeChoseong)
-                Toggle("SETTINGS_GENERATE_INCOMING_SCREEN", isOn: $needMakeIncomingPhoto)
-            }
+        ZStack {
+            Color.appBackground
+                .ignoresSafeArea()
 
-            Section("SETTINGS_SECTION_INCOMING_SCREEN") {
-                Toggle("SETTINGS_ORIGINAL_PHOTO_FULLSCREEN", isOn: $needFullscreenPhoto)
-                    .disabled(!needMakeIncomingPhoto)
-                Toggle("SETTINGS_INCOMING_INCLUDE_COMPANY", isOn: $needPhotoContainsOrg)
-                    .disabled(!needMakeIncomingPhoto)
-                Toggle("SETTINGS_INCOMING_INCLUDE_DEPARTMENT", isOn: $needPhotoContainsDept)
-                    .disabled(!needMakeIncomingPhoto)
-                Toggle("SETTINGS_INCOMING_INCLUDE_JOB_TITLE", isOn: $needPhotoContainsJob)
-                    .disabled(!needMakeIncomingPhoto)
-            }
+            VStack(spacing: 0) {
+                List {
+                    Section {
+                        settingsToggle("SETTINGS_GENERATE_NICKNAME", isOn: $needGenerateNickname)
+                        settingsToggle("SETTINGS_INCLUDE_COMPANY", isOn: $needContainsOrg)
+                        settingsToggle("SETTINGS_INCLUDE_DEPARTMENT", isOn: $needContainsDept)
+                        settingsToggle("SETTINGS_INCLUDE_JOB_TITLE", isOn: $needContainsJob)
+                        settingsToggle("SETTINGS_KOREAN_CONSONANT_SEARCH", isOn: $needMakeChoseong)
+                        settingsToggle("SETTINGS_GENERATE_INCOMING_SCREEN", isOn: $needMakeIncomingPhoto)
+                    } header: {
+                        Text("SETTINGS_SECTION_CONTACTS")
+                            .appEyebrow()
+                            .foregroundStyle(Color.appTextTertiary)
+                    }
 
-            Section("SETTINGS_SECTION_APP_INFO") {
-                LabeledContent("SETTINGS_APP_VERSION", value: Bundle.main.appVersion)
+                    Section {
+                        settingsToggle(
+                            "SETTINGS_ORIGINAL_PHOTO_FULLSCREEN",
+                            isOn: $needFullscreenPhoto,
+                            enabled: needMakeIncomingPhoto
+                        )
+                        settingsToggle(
+                            "SETTINGS_INCOMING_INCLUDE_COMPANY",
+                            isOn: $needPhotoContainsOrg,
+                            enabled: needMakeIncomingPhoto
+                        )
+                        settingsToggle(
+                            "SETTINGS_INCOMING_INCLUDE_DEPARTMENT",
+                            isOn: $needPhotoContainsDept,
+                            enabled: needMakeIncomingPhoto
+                        )
+                        settingsToggle(
+                            "SETTINGS_INCOMING_INCLUDE_JOB_TITLE",
+                            isOn: $needPhotoContainsJob,
+                            enabled: needMakeIncomingPhoto
+                        )
+                    } header: {
+                        Text("SETTINGS_SECTION_INCOMING_SCREEN")
+                            .appEyebrow()
+                            .foregroundStyle(Color.appTextTertiary)
+                    }
+
+                    Section {
+                        LabeledContent("SETTINGS_APP_VERSION", value: Bundle.main.appVersion)
+                            .foregroundStyle(Color.appTextSecondary)
+                    } header: {
+                        Text("SETTINGS_SECTION_APP_INFO")
+                            .appEyebrow()
+                            .foregroundStyle(Color.appTextTertiary)
+                    }
+                }
+                .listStyle(.insetGrouped)
+                .tint(Color.appAmberDeep)
+
+                BannerAdView(unitName: .settingsBanner)
             }
         }
         .navigationTitle("SETTINGS_TITLE")
         .navigationBarTitleDisplayMode(.inline)
+    }
 
-        BannerAdView(unitName: .settingsBanner)
-        } // VStack
+    private func settingsToggle(
+        _ title: LocalizedStringKey,
+        isOn: Binding<Bool>,
+        enabled: Bool = true
+    ) -> some View {
+        Toggle(title, isOn: isOn)
+            .foregroundStyle(enabled ? Color.appTextPrimary : Color.appDisabled)
+            .disabled(!enabled)
     }
 }
 


### PR DESCRIPTION
## Summary
- introduce a code-first design system with adaptive colors, typography, spacing, radius, motion, and gradient tokens for the new SwiftUI shell
- expand design-system adoption on Main and Settings with reusable button/card/action-row styles and semantic state colors for clearer, more consistent flows
- align the legacy UIKit contact preview with the new night palette so preview and generated-contact experiences feel like the same app

## Verification
- xcodebuild -workspace WhoCallMe.xcworkspace -scheme App -configuration Debug -destination 'platform=iOS Simulator,id=371BF853-7839-4FE1-98CA-D2FA159F19D5' build
- mise x -- tuist test
- launched the app on iPhone 17 Pro simulator for a manual smoke check

## User Flow
```mermaid
flowchart TD
    A[Main Screen]
    --> B[Convert All / Stop]
    --> C[Convert One]
    --> D[Preview]
    --> E[Settings]
    D --> F[UIKit Contact Preview]
```