### PR TITLE
Add internal skill for Korean simulator test contacts

### DIFF
--- a/.claude/skills/korean-test-contacts/SKILL.md
+++ b/.claude/skills/korean-test-contacts/SKILL.md
@@ -1,0 +1,133 @@
+# Skill: korean-test-contacts
+
+Create Korean simulator test contacts for WhoCallMe using the simulator Contacts database and `idb contacts update`.
+
+## When to use
+
+Use this skill when you need realistic Korean contacts to test:
+- contact conversion
+- 초성 search indexing
+- incoming-call image generation
+- restore / clear-photo flows
+- mixed organization / department / title rendering
+
+Do **not** use the Contacts app UI for Korean text entry through `idb ui text`.
+`idb ui text` cannot reliably type Hangul. Use the DB import path below.
+
+## Supported workflow
+
+1. Copy the current simulator AddressBook databases to a temp directory.
+2. Inject Korean contacts into the copied `AddressBook.sqlitedb`.
+3. Import that directory with `idb contacts update`.
+4. Remove stale `-wal` / `-shm` journal files.
+5. Relaunch Contacts and verify the imported rows.
+
+## Mermaid overview
+
+```mermaid
+flowchart TD
+    A[Copy simulator AddressBook DB]
+    --> B[Insert Korean contacts into temp DB]
+    --> C[idb contacts update]
+    --> D[Remove stale wal/shm files]
+    --> E[Relaunch Contacts]
+    --> F[Verify names in Contacts app]
+```
+
+## Default test set
+
+The bundled script creates these contacts:
+- 김민수 — 네이버 / 플랫폼 / iOS 개발자 / 010-1234-5678
+- 이서연 — 카카오 / 디자인 / 프로덕트 디자이너 / 010-2345-6789
+- 박지훈 — 쿠팡 / 커머스 / 백엔드 엔지니어 / 010-3456-7890
+- 최유진 — 토스 / 성장 / 마케터 / 010-4567-8901
+- 정하늘 — 라인 / AI / 리서처 / 010-5678-9012
+
+These are good defaults for WhoCallMe because they exercise:
+- common Korean family names
+- Korean section headers in Contacts
+- org / dept / title rendering
+- phone-based conversion flows
+
+## Prerequisites
+
+- Simulator booted
+- `idb` installed and working
+- Contacts app can be closed and reopened
+- Prefer the booted simulator, or pass an explicit UDID
+
+## One-command usage
+
+From the repo root:
+
+```bash
+python .claude/skills/korean-test-contacts/build_korean_contacts_db.py --udid <SIMULATOR_UDID> --output /tmp/whocallme-korean-contacts && idb contacts update --udid <SIMULATOR_UDID> /tmp/whocallme-korean-contacts && xcrun simctl terminate <SIMULATOR_UDID> com.apple.MobileAddressBook || true && rm -f "$HOME/Library/Developer/CoreSimulator/Devices/<SIMULATOR_UDID>/data/Library/AddressBook/AddressBook.sqlitedb-wal" "$HOME/Library/Developer/CoreSimulator/Devices/<SIMULATOR_UDID>/data/Library/AddressBook/AddressBook.sqlitedb-shm" "$HOME/Library/Developer/CoreSimulator/Devices/<SIMULATOR_UDID>/data/Library/AddressBook/AddressBookImages.sqlitedb-wal" "$HOME/Library/Developer/CoreSimulator/Devices/<SIMULATOR_UDID>/data/Library/AddressBook/AddressBookImages.sqlitedb-shm" && xcrun simctl launch <SIMULATOR_UDID> com.apple.MobileAddressBook
+```
+
+If using the booted simulator, replace `<SIMULATOR_UDID>` with `booted` for `simctl`, but keep the real UDID for the Python script and `idb`.
+
+## Recommended step-by-step usage
+
+### 1) Find simulator UDID
+
+```bash
+idb list-targets
+```
+
+### 2) Build temp contacts DB
+
+```bash
+python .claude/skills/korean-test-contacts/build_korean_contacts_db.py --udid 371BF853-7839-4FE1-98CA-D2FA159F19D5 --output /tmp/whocallme-korean-contacts
+```
+
+### 3) Import with idb
+
+```bash
+idb contacts update --udid 371BF853-7839-4FE1-98CA-D2FA159F19D5 /tmp/whocallme-korean-contacts
+```
+
+### 4) Clear stale journals
+
+```bash
+xcrun simctl terminate 371BF853-7839-4FE1-98CA-D2FA159F19D5 com.apple.MobileAddressBook || true
+rm -f "$HOME/Library/Developer/CoreSimulator/Devices/371BF853-7839-4FE1-98CA-D2FA159F19D5/data/Library/AddressBook/AddressBook.sqlitedb-wal"
+rm -f "$HOME/Library/Developer/CoreSimulator/Devices/371BF853-7839-4FE1-98CA-D2FA159F19D5/data/Library/AddressBook/AddressBook.sqlitedb-shm"
+rm -f "$HOME/Library/Developer/CoreSimulator/Devices/371BF853-7839-4FE1-98CA-D2FA159F19D5/data/Library/AddressBook/AddressBookImages.sqlitedb-wal"
+rm -f "$HOME/Library/Developer/CoreSimulator/Devices/371BF853-7839-4FE1-98CA-D2FA159F19D5/data/Library/AddressBook/AddressBookImages.sqlitedb-shm"
+```
+
+### 5) Relaunch and verify
+
+```bash
+xcrun simctl launch 371BF853-7839-4FE1-98CA-D2FA159F19D5 com.apple.MobileAddressBook
+sqlite3 "$HOME/Library/Developer/CoreSimulator/Devices/371BF853-7839-4FE1-98CA-D2FA159F19D5/data/Library/AddressBook/AddressBook.sqlitedb" "select Last || First as name, Organization, Department, JobTitle from ABPerson where Last in ('김','이','박','최','정') order by ROWID;"
+```
+
+## Why journal cleanup matters
+
+After `idb contacts update`, the base sqlite file may be correct but stale `-wal` / `-shm` files can cause Contacts to still show old data.
+
+If imported contacts do not appear:
+- terminate Contacts
+- remove `AddressBook.sqlitedb-wal`
+- remove `AddressBook.sqlitedb-shm`
+- remove matching image DB journals
+- relaunch Contacts
+
+## Safety notes
+
+- This workflow modifies only simulator contacts, not a physical device.
+- The script copies the current AddressBook DB first, so built-in sample contacts are preserved.
+- Re-running the script is idempotent for the bundled default set; existing matching name + phone entries are skipped.
+
+## Reset options
+
+- Erase simulator for a full reset
+- Or restore from a fresh copied AddressBook DB without injected rows
+
+## Validation checklist
+
+- Contacts app shows Korean section headers like `ㄱ`, `ㅂ`, `ㅇ`, `ㅈ`, `ㅊ`
+- Imported names are visible in the list
+- Detail view shows company / department / title
+- WhoCallMe can convert, preview, restore, and clear against these contacts

--- a/.claude/skills/korean-test-contacts/build_korean_contacts_db.py
+++ b/.claude/skills/korean-test-contacts/build_korean_contacts_db.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+
+
+DEFAULT_CONTACTS = [
+    {
+        "first": "민수",
+        "last": "김",
+        "organization": "네이버",
+        "department": "플랫폼",
+        "job_title": "iOS 개발자",
+        "note": "WhoCallMe 한국어 테스트 연락처",
+        "phone": "010-1234-5678",
+    },
+    {
+        "first": "서연",
+        "last": "이",
+        "organization": "카카오",
+        "department": "디자인",
+        "job_title": "프로덕트 디자이너",
+        "note": "WhoCallMe 한국어 테스트 연락처",
+        "phone": "010-2345-6789",
+    },
+    {
+        "first": "지훈",
+        "last": "박",
+        "organization": "쿠팡",
+        "department": "커머스",
+        "job_title": "백엔드 엔지니어",
+        "note": "WhoCallMe 한국어 테스트 연락처",
+        "phone": "010-3456-7890",
+    },
+    {
+        "first": "유진",
+        "last": "최",
+        "organization": "토스",
+        "department": "성장",
+        "job_title": "마케터",
+        "note": "WhoCallMe 한국어 테스트 연락처",
+        "phone": "010-4567-8901",
+    },
+    {
+        "first": "하늘",
+        "last": "정",
+        "organization": "라인",
+        "department": "AI",
+        "job_title": "리서처",
+        "note": "WhoCallMe 한국어 테스트 연락처",
+        "phone": "010-5678-9012",
+    },
+]
+
+
+def simulator_addressbook_dir(udid: str) -> Path:
+    return Path.home() / "Library/Developer/CoreSimulator/Devices" / udid / "data/Library/AddressBook"
+
+
+def copy_databases(source_dir: Path, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_dir / "AddressBook.sqlitedb", output_dir / "AddressBook.sqlitedb")
+    shutil.copy2(source_dir / "AddressBookImages.sqlitedb", output_dir / "AddressBookImages.sqlitedb")
+
+
+def contact_exists(cursor: sqlite3.Cursor, contact: dict[str, str]) -> bool:
+    cursor.execute(
+        """
+        SELECT 1
+        FROM ABPerson person
+        LEFT JOIN ABMultiValue multi ON multi.record_id = person.ROWID AND multi.property = 3
+        WHERE person.First = ? AND person.Last = ? AND multi.value = ?
+        LIMIT 1
+        """,
+        (contact["first"], contact["last"], contact["phone"]),
+    )
+    return cursor.fetchone() is not None
+
+
+def insert_contacts(db_path: Path) -> None:
+    connection = sqlite3.connect(db_path)
+    connection.create_function("ab_generate_guid", 0, lambda: str(uuid.uuid4()).upper())
+    connection.create_function("ab_update_value_from_trigger", 3, lambda value, _field, _rowid: value)
+    cursor = connection.cursor()
+    now = int(time.time())
+
+    for contact in DEFAULT_CONTACTS:
+        if contact_exists(cursor, contact):
+            continue
+
+        cursor.execute(
+            """
+            INSERT INTO ABPerson (
+                First,
+                Last,
+                Organization,
+                Department,
+                JobTitle,
+                Note,
+                Kind,
+                StoreID,
+                PersonLink,
+                guid,
+                CreationDate,
+                ModificationDate,
+                FirstSort,
+                LastSort,
+                FirstSortSection,
+                LastSortSection,
+                FirstSortLanguageIndex,
+                LastSortLanguageIndex
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                contact["first"],
+                contact["last"],
+                contact["organization"],
+                contact["department"],
+                contact["job_title"],
+                contact["note"],
+                0,
+                0,
+                -1,
+                str(uuid.uuid4()).upper(),
+                now,
+                now,
+                contact["first"],
+                contact["last"],
+                contact["last"],
+                contact["last"],
+                1,
+                1,
+            ),
+        )
+        record_id = cursor.lastrowid
+        cursor.execute(
+            "INSERT INTO ABMultiValue (record_id, property, identifier, label, value, guid) VALUES (?, 3, 0, 3, ?, ?)",
+            (record_id, contact["phone"], str(uuid.uuid4()).upper()),
+        )
+
+    connection.commit()
+    connection.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build a temp Contacts DB with Korean test contacts for WhoCallMe")
+    parser.add_argument("--udid", required=True, help="Simulator UDID")
+    parser.add_argument("--output", required=True, help="Output directory for copied contacts DB")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    source_dir = simulator_addressbook_dir(args.udid)
+    output_dir = Path(args.output)
+
+    copy_databases(source_dir, output_dir)
+    insert_contacts(output_dir / "AddressBook.sqlitedb")
+
+    print(f"Prepared Korean test contacts DB at: {output_dir}")
+    print("Next step:")
+    print(f"idb contacts update --udid {args.udid} {output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a project-internal skill that documents the reliable `idb contacts update` workflow for Korean simulator test contacts
- include a reusable helper script that builds a temporary Contacts database with realistic Korean names, companies, departments, titles, and phone numbers for WhoCallMe testing
- document the required sqlite journal cleanup and verification steps so imported contacts appear correctly in the simulator Contacts app

## Verification
- python .claude/skills/korean-test-contacts/build_korean_contacts_db.py --udid 371BF853-7839-4FE1-98CA-D2FA159F19D5 --output /tmp/whocallme-skill-check
- sqlite3 /tmp/whocallme-skill-check/AddressBook.sqlitedb "select Last || First as name, count(*) from ABPerson where Last in ('김','이','박','최','정') group by Last, First order by Last, First;"

## Workflow
```mermaid
flowchart TD
    A[Build temp Korean contacts DB]
    --> B[idb contacts update]
    --> C[Clear stale wal/shm]
    --> D[Relaunch Contacts]
    --> E[Verify imported contacts]
```