### PR TITLE
Fix deprecated in-app review request API

### DIFF
--- a/Projects/App/Sources/App.swift
+++ b/Projects/App/Sources/App.swift
@@ -67,7 +67,15 @@ struct WhoCallMeApp: App {
                 LSDefaults.increaseLaunchCount()
                 isLaunched = true
                 if LSDefaults.LaunchCount > 0 && LSDefaults.LaunchCount % 30 == 0 {
-                    SKStoreReviewController.requestReview()
+                    if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+                        if #available(iOS 18.0, *) {
+                            AppStore.requestReview(in: scene)
+                        } else if #available(iOS 14.0, *) {
+                            SKStoreReviewController.requestReview(in: scene)
+                        } else {
+                            SKStoreReviewController.requestReview()
+                        }
+                    }
                 }
             }
 

--- a/Projects/App/Sources/App.swift
+++ b/Projects/App/Sources/App.swift
@@ -68,13 +68,7 @@ struct WhoCallMeApp: App {
                 isLaunched = true
                 if LSDefaults.LaunchCount > 0 && LSDefaults.LaunchCount % 30 == 0 {
                     if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
-                        if #available(iOS 18.0, *) {
-                            AppStore.requestReview(in: scene)
-                        } else if #available(iOS 14.0, *) {
-                            SKStoreReviewController.requestReview(in: scene)
-                        } else {
-                            SKStoreReviewController.requestReview()
-                        }
+                        AppStore.requestReview(in: scene)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- replace the deprecated direct `SKStoreReviewController.requestReview()` call with the modern scene-aware `AppStore.requestReview(in:)` API in `App.swift`
- simplify the implementation to the iOS 18 path used by the current app target instead of carrying obsolete fallback branches
- keep the existing launch-count trigger behavior unchanged so review prompts still occur on the same cadence

Closes #9

## Verification
- xcodebuild -workspace WhoCallMe.xcworkspace -scheme App -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build

## User Flow
```mermaid
flowchart TD
    A[App becomes active]
    --> B{Launch count % 30 == 0?}
    B -- No --> Z[No review prompt]
    B -- Yes --> C[Find foreground UIWindowScene]
    C --> D{Scene found?}
    D -- No --> Z
    D -- Yes --> E[AppStore.requestReview(in: scene)]
```