### PR TITLE
Fix DynamicThirdParty module map warning

### DIFF
--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -14,7 +14,8 @@ let project = Project(
                            .package(product: "FirebaseAnalytics", type: .runtime),
                            .package(product: "FirebaseMessaging", type: .runtime),
                            .package(product: "FirebaseRemoteConfig", type: .runtime)
-            ]
+            ],
+            settings: .settings(base: ["DEFINES_MODULE": "NO"])
         ),
     ]
 )


### PR DESCRIPTION
## Summary
- disable module definition for the `DynamicThirdParty` aggregation target to stop Xcode from trying to generate a module map without an umbrella header
- keep the change minimal in Tuist source instead of adding an artificial umbrella header to a package-wrapper target
- preserve the existing Firebase dependency wrapper behavior while removing the warning source

Closes #11

## Verification
- reviewed the generated-source change in `Projects/DynamicThirdParty/Project.swift`
- attempted `mise x -- tuist install && mise x -- tuist generate`, but validation is blocked in this environment because `tuist auth login` is required

## User Flow
```mermaid
flowchart TD
    A[Tuist generates DynamicThirdParty target]
    --> B{DEFINES_MODULE enabled?}
    B -- Yes --> C[Try to generate module map]
    C --> D[Warn about missing umbrella header]
    B -- No --> E[Skip module-map generation]
    E --> F[No umbrella-header warning]
```