### PR TITLE
Fix missing AccentColor asset warning

### DIFF
--- a/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4B",
+          "green" : "0xA3",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## Summary
- add the missing `AccentColor` asset to the app asset catalog so the configured global accent color name resolves correctly at build time
- use a warm amber value aligned with the current design system instead of changing build settings or removing the accent-color reference
- keep the fix isolated to asset-catalog data with no code or project-setting churn

Closes #13

## Verification
- xcodebuild -workspace WhoCallMe.xcworkspace -scheme App -configuration Debug build
- confirmed the `Accent color 'AccentColor' is not present in any asset catalogs.` warning no longer appears

## User Flow
```mermaid
flowchart TD
    A[Build app assets]
    --> B{AccentColor asset exists?}
    B -- No --> C[Emit missing accent color warning]
    B -- Yes --> D[Resolve configured accent color]
    D --> E[Build without AccentColor warning]
```