### PR TITLE
refactor: remove dead UIKit legacy stubs

### DIFF
--- a/Projects/App/Sources/Preview/ContactTemplateViewController.swift
+++ b/Projects/App/Sources/Preview/ContactTemplateViewController.swift
@@ -91,14 +91,6 @@ class ContactTemplateViewController: UIViewController, UITableViewDataSource, UI
         self.useThumbNail = Bool(self.useThumbNail);
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-
-    }
-    
     override func viewDidAppear(_ animated: Bool) {
         Analytics.setScreenName(for: self);
     }
@@ -296,14 +288,4 @@ class ContactTemplateViewController: UIViewController, UITableViewDataSource, UI
         self.useThumbNail = Bool(self.useThumbNail);
     }
     
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        // Get the new view controller using segue.destinationViewController.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/Projects/App/Sources/leesam/Analytics+.swift
+++ b/Projects/App/Sources/leesam/Analytics+.swift
@@ -9,12 +9,6 @@
 import UIKit
 import FirebaseAnalytics
 
-extension UIViewController{
-    func setAnalyticScreenName(){
-        Analytics.setScreenName(for: self);
-    }
-}
-
 extension Analytics{
     static func setScreenName(for viewController: UIViewController){
         var name : String?;
@@ -45,15 +39,6 @@ extension Analytics{
         case finishRestore = "복원완료"
         case startClear = "사진삭제시작"
         case finishClear = "사진삭제완료"
-    }
-    
-    class LeesamEventProperty{
-        static let autoPlay = "자동재생"
-        static let course = "강좌번호"
-        static let lecture = "강의번호"
-        static let lectureTitle = "강의제목"
-        static let lectureUrl = "강의파일"
-        static let speed = "재생속도"
     }
     
     /*static func logSiwonEvent(_ event: SiwonEvent, parameters: [String : Any]? = nil){


### PR DESCRIPTION
## Goal and success criteria
- Remove only high-confidence dead UIKit legacy without changing user-facing behavior.
- Preserve active SwiftUI flows and the storyboard-backed preview bridge.

## Summary
- remove empty lifecycle overrides and old storyboard navigation comments from `ContactTemplateViewController`
- remove unused analytics helper API and dead event property constants
- keep `Main.storyboard` and preview rendering dependencies untouched because they remain active

## Dependencies and critical path
- Verified candidates were limited to no-op code and unused helpers.
- Active preview/template rendering remains on the existing UIKit bridge.

```mermaid
flowchart TD
    A[Identify dead UIKit candidate] --> B[Triple-check safety]
    B --> C[Remove no-op or unused code]
    C --> D[Build verification]
    D --> E[Keep active preview bridge intact]
```

## Risks and mitigations
- Risk: removing hidden runtime dependencies
  - Mitigation: cleanup was limited to no-op overrides and unused helpers only
- Risk: preview regression
  - Mitigation: no storyboard or preview rendering path was changed

## Verification and release checklist
- [x] `xcodebuild -workspace WhoCallMe.xcworkspace -scheme App -configuration Debug build`
- [x] Build re-run after each deletion step during cleanup
- [x] No active storyboard preview dependency removed
- [ ] Reviewer smoke-check preview / convert / restore if desired