### PR TITLE
fix: resolve Crashlytics run script path

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -76,15 +76,22 @@ let project = Project(
             scripts: [
                 .post(
                     script: """
-                    FIREBASE_SOURCEPACKAGES_ROOT="${BUILD_DIR%/Build/*}/SourcePackages"
-                    CRASHLYTICS_RUN_SCRIPT=$(ls "$FIREBASE_SOURCEPACKAGES_ROOT"/registry/downloads/firebase/firebase-ios-sdk/*/Crashlytics/run 2>/dev/null | sort -V | tail -n 1)
+                    SOURCE_PACKAGES_ROOT="${SOURCE_PACKAGES_DIR_PATH:-${BUILD_DIR%/Build/*}/SourcePackages}"
+                    CRASHLYTICS_RUN_SCRIPT=""
+
+                    for candidate in \
+                      "$SOURCE_PACKAGES_ROOT/checkouts/firebase-ios-sdk/Crashlytics/run" \
+                      "$SOURCE_PACKAGES_ROOT/registry/downloads/firebase/firebase-ios-sdk/Crashlytics/run" \
+                      "$SOURCE_PACKAGES_ROOT"/registry/downloads/firebase/firebase-ios-sdk/*/Crashlytics/run
+                    do
+                      if [ -f "$candidate" ]; then
+                        CRASHLYTICS_RUN_SCRIPT="$candidate"
+                        break
+                      fi
+                    done
 
                     if [ -z "$CRASHLYTICS_RUN_SCRIPT" ]; then
-                      CRASHLYTICS_RUN_SCRIPT="$FIREBASE_SOURCEPACKAGES_ROOT/checkouts/firebase-ios-sdk/Crashlytics/run"
-                    fi
-
-                    if [ ! -f "$CRASHLYTICS_RUN_SCRIPT" ]; then
-                      echo "error: Firebase Crashlytics run script not found at $CRASHLYTICS_RUN_SCRIPT"
+                      echo "error: Firebase Crashlytics run script not found under $SOURCE_PACKAGES_ROOT"
                       exit 1
                     fi
 


### PR DESCRIPTION
## Goal and success criteria
- Fix the Crashlytics build phase so simulator/device builds can find Firebase's `run` script across current SourcePackages layouts.
- Keep the change limited to the Tuist-managed script phase.

## Summary
- use `SOURCE_PACKAGES_DIR_PATH` when available, with the existing DerivedData-based fallback
- search checkout, registry direct, and registry versioned Firebase package layouts
- emit a clearer error when no Crashlytics `run` script is found

## Dependencies and critical path
- `Projects/App/Project.swift` owns the Tuist-managed Crashlytics post-build script
- Xcode must pick up the regenerated project after `tuist install` + `tuist generate`

```mermaid
flowchart TD
    A[Xcode build phase] --> B[Resolve SourcePackages root]
    B --> C{Crashlytics run script found?}
    C -->|checkout layout| D[Execute run script]
    C -->|registry layout| D
    C -->|not found| E[Clear build error]
```

## Risks and mitigations
- Risk: path still varies by package manager layout
  - Mitigation: script now checks multiple known Firebase package layouts
- Risk: project file not updated in Xcode
  - Mitigation: regenerate Tuist project after auth/install succeeds

## Verification and release checklist
- [x] Reviewed `Projects/App/Project.swift` diff
- [x] Shell syntax check passed for extracted script body
- [ ] Run `tuist auth login`
- [ ] Run `mise x -- tuist install`
- [ ] Run `mise x -- tuist generate`
- [ ] Rebuild in Xcode / simulator