### PR TITLE
refactor: use ImageRenderer for contact images

### DIFF
--- a/Projects/App/Sources/Controller/ContactImageRenderer.swift
+++ b/Projects/App/Sources/Controller/ContactImageRenderer.swift
@@ -9,34 +9,19 @@ struct ContactImageRenderer {
 
         let size = CGSize(width: 375, height: 667)
 
-        let view = ContactTemplateView(
+        let content = ContactTemplateView(
             contact: contact,
             originalImage: originalImage,
             generatedImageData: nil,
             isPreviewMode: false
         )
         .ignoresSafeArea()
+        .frame(width: size.width, height: size.height)
 
-        let host = UIHostingController(rootView: view)
-        host.view.frame = CGRect(origin: .zero, size: size)
-        host.view.backgroundColor = .clear
+        let renderer = ImageRenderer(content: content)
+        renderer.proposedSize = ProposedViewSize(size)
+        renderer.scale = UIScreen.main.scale
 
-        let window = UIWindow(frame: host.view.bounds)
-        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-            window.windowScene = scene
-        }
-        window.rootViewController = host
-        window.makeKeyAndVisible()
-
-        host.view.setNeedsLayout()
-        host.view.layoutIfNeeded()
-
-        let renderer = UIGraphicsImageRenderer(size: size)
-        let image = renderer.image { ctx in
-            host.view.layer.render(in: ctx.cgContext)
-        }
-
-        window.isHidden = true
-        return image
+        return renderer.uiImage
     }
 }


### PR DESCRIPTION
## Goal and success criteria
- Replace the temporary window-based contact image rendering path with a modern SwiftUI renderer.
- Keep generated contact image behavior and output sizing unchanged.

## Summary
- replace `UIHostingController` + temporary `UIWindow` snapshotting with SwiftUI `ImageRenderer`
- preserve `ContactImageRenderer.render(contact:originalImage:)` API and `375x667` output sizing
- remove unnecessary window/scene side effects from offscreen rendering

## Dependencies and critical path
- `ContactImageRenderer` remains the single entry point used by contact conversion
- `ContactTemplateView` is still the shared SwiftUI source of truth for generated images

```mermaid
flowchart TD
    A[ContactTemplateView] --> B[ImageRenderer]
    B --> C[UIImage]
    C --> D[Saved contact imageData]
```

## Risks and mitigations
- Risk: rendered output could differ subtly from previous snapshot path
  - Mitigation: keep the same fixed render size and screen scale
- Risk: availability issues
  - Mitigation: app deployment target is iOS 18.0, so `ImageRenderer` is supported

## Verification and release checklist
- [x] `xcodebuild -workspace WhoCallMe.xcworkspace -scheme App -configuration Debug build`
- [x] Public render API unchanged
- [x] Temporary window creation removed
