### PR TITLE
fix: restore original photos after clear

### DIFF
--- a/Projects/App/Sources/Controller/ContactService.swift
+++ b/Projects/App/Sources/Controller/ContactService.swift
@@ -92,14 +92,29 @@ final class ContactService: ObservableObject {
     ) async throws {
         try await ContactStore.shared.requestAccess()
         let contacts = try await ContactStore.shared.fetchAll(keys: ContactStore.keysForClear)
+        let backupByID = Dictionary(uniqueKeysWithValues: fetchAllBackups().map { ($0.id, $0) })
+        var didUpdateBackup = false
         let total = contacts.count
 
         for (i, contact) in contacts.enumerated() {
             guard !isCancelled() else { return }
             guard let target = contact.mutableCopy() as? CNMutableContact else { continue }
+
+            // Mark generated image as cleared so Restore can safely recover original photo.
+            if let backup = backupByID[contact.identifier],
+               contact.imageData == backup.generatedImage,
+               backup.generatedImage != nil {
+                backup.generatedImage = nil
+                didUpdateBackup = true
+            }
+
             target.imageData = nil
             try await ContactStore.shared.save(target)
             onProgress(i + 1, total)
+        }
+
+        if didUpdateBackup {
+            try modelContext.save()
         }
     }
 
@@ -154,5 +169,4 @@ final class ContactService: ObservableObject {
         return (try? modelContext.fetchCount(descriptor)) ?? 0
     }
 }
-
 


### PR DESCRIPTION
## Goal and success criteria
- Ensure Restore can recover original photos even after Clear Photos was used.
- Preserve existing safety behavior for manually changed photos.

## Summary
- update `clearAllPhotos()` to clear matching `backup.generatedImage` metadata when a generated photo is removed
- keep backup originals intact so Restore can bring back the original photo after a clear operation
- leave normal restore behavior unchanged for non-generated or manually changed photos

## Dependencies and critical path
- `Clear Photos` and `Restore` both depend on `ContactBackup` state in `ContactService`
- this change keeps backup metadata aligned with the contact state after Clear Photos

```mermaid
flowchart TD
    A[Converted contact with generated image] --> B[Clear Photos]
    B --> C[Clear backup.generatedImage marker]
    C --> D[Restore]
    D --> E[Original backup photo restored]
```

## Risks and mitigations
- Risk: restore overwrites a manually changed user photo
  - Mitigation: only clear the generated-image marker when the current photo matches the app-generated image
- Risk: backup state drifts from contact state after clear
  - Mitigation: save updated backup metadata alongside the clear flow

## Verification and release checklist
- [x] `xcodebuild -workspace WhoCallMe.xcworkspace -scheme App -configuration Debug build`
- [x] `xcodebuild -workspace WhoCallMe.xcworkspace -scheme App -destination "platform=iOS Simulator,name=iPhone 17 Pro" test`
- [x] Restore-after-clear path preserves original photo backups
