### PR TITLE
fix: stabilize generated image detection

### DIFF
--- a/Projects/App/Sources/Controller/ContactService.swift
+++ b/Projects/App/Sources/Controller/ContactService.swift
@@ -63,7 +63,10 @@ final class ContactService: ObservableObject {
             ContactConverter.restoreIndex(target, backup: backup)
 
             // Only restore original if user hasn't manually changed the photo since conversion
-            if contact.imageData == backup?.generatedImage {
+            if GeneratedImageDetector.isGeneratedImage(
+                currentImageData: contact.imageData,
+                generatedImageData: backup?.generatedImage
+            ) {
                 target.imageData = backup?.imageData
             }
 
@@ -115,7 +118,10 @@ final class ContactService: ObservableObject {
                 backup?.imageData = imageData
             }
             if let backup { modelContext.insert(backup) }
-        } else if contact.imageData != backup?.generatedImage {
+        } else if !GeneratedImageDetector.isGeneratedImage(
+            currentImageData: contact.imageData,
+            generatedImageData: backup?.generatedImage
+        ) {
             // User manually changed their photo since last conversion — track new original
             backup?.imageData = contact.imageData
         }
@@ -154,5 +160,4 @@ final class ContactService: ObservableObject {
         return (try? modelContext.fetchCount(descriptor)) ?? 0
     }
 }
-
 

--- a/Projects/App/Sources/Controller/GeneratedImageDetector.swift
+++ b/Projects/App/Sources/Controller/GeneratedImageDetector.swift
@@ -1,0 +1,82 @@
+import UIKit
+
+enum GeneratedImageDetector {
+    private static let maxAverageHashDistance = 8
+
+    static func isGeneratedImage(currentImageData: Data?, generatedImageData: Data?) -> Bool {
+        guard let currentImageData, let generatedImageData else { return false }
+        return isLikelySameImageData(currentImageData, generatedImageData)
+    }
+
+    static func isLikelySameImageData(_ lhs: Data?, _ rhs: Data?) -> Bool {
+        guard let lhs, let rhs else { return false }
+
+        if lhs == rhs {
+            return true
+        }
+
+        guard
+            let lhsImage = UIImage(data: lhs),
+            let rhsImage = UIImage(data: rhs),
+            let lhsHash = averageHash(lhsImage),
+            let rhsHash = averageHash(rhsImage)
+        else {
+            return false
+        }
+
+        let distance = hammingDistance(lhsHash, rhsHash)
+        return distance <= maxAverageHashDistance
+    }
+
+    private static func averageHash(_ image: UIImage) -> UInt64? {
+        let size = CGSize(width: 8, height: 8)
+        var pixels = [UInt8](repeating: 0, count: Int(size.width * size.height))
+        let colorSpace = CGColorSpaceCreateDeviceGray()
+
+        guard let cgImage = normalizedCGImage(from: image) else { return nil }
+        guard let context = CGContext(
+            data: &pixels,
+            width: Int(size.width),
+            height: Int(size.height),
+            bitsPerComponent: 8,
+            bytesPerRow: Int(size.width),
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        ) else {
+            return nil
+        }
+
+        context.interpolationQuality = .low
+        context.draw(cgImage, in: CGRect(origin: .zero, size: size))
+
+        let average = pixels.reduce(0, { $0 + Int($1) }) / pixels.count
+        var hash: UInt64 = 0
+
+        for (index, pixel) in pixels.enumerated() where Int(pixel) >= average {
+            hash |= UInt64(1) << UInt64(index)
+        }
+
+        return hash
+    }
+
+    private static func normalizedCGImage(from image: UIImage) -> CGImage? {
+        if let cgImage = image.cgImage {
+            return cgImage
+        }
+
+        let size = image.size
+        guard size.width > 0, size.height > 0 else { return nil }
+
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        let normalized = renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: size))
+        }
+        return normalized.cgImage
+    }
+
+    private static func hammingDistance(_ lhs: UInt64, _ rhs: UInt64) -> Int {
+        Int((lhs ^ rhs).nonzeroBitCount)
+    }
+}

--- a/Projects/App/Sources/Views/ContactTemplateView.swift
+++ b/Projects/App/Sources/Views/ContactTemplateView.swift
@@ -16,7 +16,11 @@ struct ContactTemplateView: View {
 
         guard let data = contact.imageData else { return nil }
 
-        if isPreviewMode, let generatedImageData, data == generatedImageData {
+        if isPreviewMode,
+           GeneratedImageDetector.isGeneratedImage(
+               currentImageData: data,
+               generatedImageData: generatedImageData
+           ) {
             return nil
         }
 

--- a/Projects/App/Tests/GeneratedImageDetectorTests.swift
+++ b/Projects/App/Tests/GeneratedImageDetectorTests.swift
@@ -5,7 +5,7 @@ import UIKit
 struct GeneratedImageDetectorTests {
     @Test
     func isLikelySameImageData_whenEncodingDiffers_returnsTrue() {
-        let image = makePatternImage(isFlipped: false)
+        let image = makeTestImage(isFlipped: false)
         let pngData = image.pngData()
         let jpegData = image.jpegData(compressionQuality: 0.6)
 
@@ -16,8 +16,8 @@ struct GeneratedImageDetectorTests {
 
     @Test
     func isGeneratedImage_whenDifferentImage_returnsFalse() {
-        let generated = makePatternImage(isFlipped: false).pngData()
-        let manual = makePatternImage(isFlipped: true).pngData()
+        let generated = makeTestImage(isFlipped: false).pngData()
+        let manual = makeTestImage(isFlipped: true).pngData()
 
         let result = GeneratedImageDetector.isGeneratedImage(
             currentImageData: manual,
@@ -29,7 +29,7 @@ struct GeneratedImageDetectorTests {
 
     @Test
     func isGeneratedImage_whenCurrentMatchesGeneratedVisually_returnsTrue() {
-        let baseImage = makePatternImage(isFlipped: false)
+        let baseImage = makeTestImage(isFlipped: false)
         let generated = baseImage.pngData()
         let rewritten = baseImage.jpegData(compressionQuality: 0.7)
 
@@ -41,7 +41,7 @@ struct GeneratedImageDetectorTests {
         #expect(result)
     }
 
-    private func makePatternImage(isFlipped: Bool, size: CGSize = CGSize(width: 64, height: 64)) -> UIImage {
+    private func makeTestImage(isFlipped: Bool, size: CGSize = CGSize(width: 64, height: 64)) -> UIImage {
         let renderer = UIGraphicsImageRenderer(size: size)
         return renderer.image { context in
             UIColor.black.setFill()

--- a/Projects/App/Tests/GeneratedImageDetectorTests.swift
+++ b/Projects/App/Tests/GeneratedImageDetectorTests.swift
@@ -1,19 +1,21 @@
-import XCTest
+import Testing
 import UIKit
 @testable import App
 
-final class GeneratedImageDetectorTests: XCTestCase {
-    func testIsLikelySameImageData_whenEncodingDiffers_returnsTrue() {
+struct GeneratedImageDetectorTests {
+    @Test
+    func isLikelySameImageData_whenEncodingDiffers_returnsTrue() {
         let image = makePatternImage(isFlipped: false)
         let pngData = image.pngData()
         let jpegData = image.jpegData(compressionQuality: 0.6)
 
         let result = GeneratedImageDetector.isLikelySameImageData(pngData, jpegData)
 
-        XCTAssertTrue(result)
+        #expect(result)
     }
 
-    func testIsGeneratedImage_whenDifferentImage_returnsFalse() {
+    @Test
+    func isGeneratedImage_whenDifferentImage_returnsFalse() {
         let generated = makePatternImage(isFlipped: false).pngData()
         let manual = makePatternImage(isFlipped: true).pngData()
 
@@ -22,10 +24,11 @@ final class GeneratedImageDetectorTests: XCTestCase {
             generatedImageData: generated
         )
 
-        XCTAssertFalse(result)
+        #expect(!result)
     }
 
-    func testIsGeneratedImage_whenCurrentMatchesGeneratedVisually_returnsTrue() {
+    @Test
+    func isGeneratedImage_whenCurrentMatchesGeneratedVisually_returnsTrue() {
         let baseImage = makePatternImage(isFlipped: false)
         let generated = baseImage.pngData()
         let rewritten = baseImage.jpegData(compressionQuality: 0.7)
@@ -35,7 +38,7 @@ final class GeneratedImageDetectorTests: XCTestCase {
             generatedImageData: generated
         )
 
-        XCTAssertTrue(result)
+        #expect(result)
     }
 
     private func makePatternImage(isFlipped: Bool, size: CGSize = CGSize(width: 64, height: 64)) -> UIImage {
@@ -53,3 +56,4 @@ final class GeneratedImageDetectorTests: XCTestCase {
         }
     }
 }
+

--- a/Projects/App/Tests/GeneratedImageDetectorTests.swift
+++ b/Projects/App/Tests/GeneratedImageDetectorTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import UIKit
+@testable import App
+
+final class GeneratedImageDetectorTests: XCTestCase {
+    func testIsLikelySameImageData_whenEncodingDiffers_returnsTrue() {
+        let image = makePatternImage(isFlipped: false)
+        let pngData = image.pngData()
+        let jpegData = image.jpegData(compressionQuality: 0.6)
+
+        let result = GeneratedImageDetector.isLikelySameImageData(pngData, jpegData)
+
+        XCTAssertTrue(result)
+    }
+
+    func testIsGeneratedImage_whenDifferentImage_returnsFalse() {
+        let generated = makePatternImage(isFlipped: false).pngData()
+        let manual = makePatternImage(isFlipped: true).pngData()
+
+        let result = GeneratedImageDetector.isGeneratedImage(
+            currentImageData: manual,
+            generatedImageData: generated
+        )
+
+        XCTAssertFalse(result)
+    }
+
+    func testIsGeneratedImage_whenCurrentMatchesGeneratedVisually_returnsTrue() {
+        let baseImage = makePatternImage(isFlipped: false)
+        let generated = baseImage.pngData()
+        let rewritten = baseImage.jpegData(compressionQuality: 0.7)
+
+        let result = GeneratedImageDetector.isGeneratedImage(
+            currentImageData: rewritten,
+            generatedImageData: generated
+        )
+
+        XCTAssertTrue(result)
+    }
+
+    private func makePatternImage(isFlipped: Bool, size: CGSize = CGSize(width: 64, height: 64)) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            UIColor.black.setFill()
+            context.cgContext.fill(CGRect(origin: .zero, size: size))
+
+            UIColor.white.setFill()
+            if isFlipped {
+                context.cgContext.fill(CGRect(x: size.width / 2, y: 0, width: size.width / 2, height: size.height))
+            } else {
+                context.cgContext.fill(CGRect(x: 0, y: 0, width: size.width / 2, height: size.height))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Goal and success criteria
- Reliably distinguish app-generated WhoCallMe images from real user photos.
- Prevent preview and restore from depending solely on exact image data equality.

## Summary
- add `GeneratedImageDetector` with exact-match fast path and perceptual image matching fallback
- use the detector in restore logic so re-encoded generated images can still be restored safely
- use the detector in preview logic so generated images are not shown as nested real photos
- add focused tests covering re-encoded image matching and mismatch cases

## Dependencies and critical path
- `ContactService` depends on the detector for restore and conversion-time photo safety
- `ContactTemplateView` depends on the detector for preview nested-photo suppression
- tests cover the detector directly to lock down behavior

```mermaid
flowchart TD
    A[Current contact imageData] --> B{Generated image?
Exact or perceptual match}
    B -->|Yes| C[Preview hides nested photo]
    B -->|Yes| D[Restore can replace with original backup photo]
    B -->|No| E[Treat as real user photo]
```

## Risks and mitigations
- Risk: false positive or false negative image matching
  - Mitigation: exact data match first, perceptual hash fallback, focused tests added
- Risk: manual user photos being overwritten
  - Mitigation: only treat current photo as generated when detector matches the saved generated image

## Verification and release checklist
- [x] `mise x -- tuist install`
- [x] `mise x -- tuist generate`
- [x] `xcodebuild -workspace WhoCallMe.xcworkspace -scheme App -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:AppTests/GeneratedImageDetectorTests test`
- [x] 3 detector tests passed
